### PR TITLE
Fix styling nits and some typos across the project

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -1,5 +1,4 @@
-Fluent Syntax Guide
-===================
+# Fluent Syntax Guide
 
 Fluent is a localization paradigm designed to unleash the expressive power
 of the natural language. The format used to describe translation resources
@@ -9,5 +8,5 @@ FTL is designed to be simple to read, but at the same time allows to represent
 complex concepts from natural languages like gender, plurals, conjugations,
 and others.
 
-The following chapters will demonstrate how to use FTL to solve localization 
+The following chapters will demonstrate how to use FTL to solve localization
 challenges. Each chapter contains a hands-on example of simple FTL concepts.

--- a/guide/attributes.md
+++ b/guide/attributes.md
@@ -1,5 +1,5 @@
-DOM Attributes
---------------
+# DOM Attributes
+
 ```
 login-input = Predefined value
     .placeholder = example@email.com
@@ -10,15 +10,15 @@ login-input = Predefined value
 
 UI elements often contain multiple translatable messages per one widget. For
 example, an HTML form input may have a value, but also a `placeholder`
-attribute, `aria-label` attribute and maybe a `title` attribute.
+attribute, `aria-label` attribute, and maybe a `title` attribute.
 
-Another example would be a Web Component confirm window with an `ok` button,
-`cancel` button and a message.
+Another example would be a Web Component confirm window with an `OK` button,
+`Cancel` button, and a message.
 
 In order to prevent having to define multiple separate messages for representing
 different strings within a single element, FTL allows you to add attributes to
 messages.
 
-This feature is particularly useful in translating more complex widgets since
-thanks to all attributes being stores on a single unit it's easier for editors,
-comments and tools to identify and work with the given message.
+This feature is particularly useful in translating more complex widgets since,
+thanks to all attributes being stores on a single unit, it's easier for editors,
+comments, and tools to identify and work with the given message.

--- a/guide/builtins.md
+++ b/guide/builtins.md
@@ -1,12 +1,12 @@
-Builtins
---------
+# Builtins
 
+```
 emails = You have { $unreadEmails } unread emails.
 emails2 = You have { NUMBER($unreadEmails) } unread emails.
 
 last-notice =
     | Last checked: { DATETIME($lastChecked, day: "numeric", month: long") }.
-
+```
 ```json
 {
     "lastChecked": "2016-04-22T08:13:56.354Z",

--- a/guide/comments.md
+++ b/guide/comments.md
@@ -1,5 +1,5 @@
-Comments
---------
+# Comments
+
 ```
 // This comment is for the whole file.
 
@@ -19,9 +19,9 @@ logout = Logout { $user }
 }
 ```
 
-In FTL Comments can be standalone or bound to a file, message or section.
+In FTL, Comments can be standalone or bound to a file, message, or section.
 
-If a comment is located right above section or message, it belongs to it and
+If a comment is located right above a section or message, it belongs to it and
 localization tools will present it in its context.
 If a comment is located at the top of the file it will be bound to the whole file.
 

--- a/guide/external.md
+++ b/guide/external.md
@@ -1,5 +1,5 @@
-Interpolation and External Arguments
-------------------------------------
+# Interpolation and External Arguments
+
 ```
 welcome = Welcome { $user }
 unreadEmails = { $user } has { $emailCount } unread emails.
@@ -10,7 +10,6 @@ unreadEmails = { $user } has { $emailCount } unread emails.
     "emailCount": 5
 }
 ```
-
 
 Another common common use case for a placeable is to put an external argument,
 provided by the developer, into the string.

--- a/guide/functions.md
+++ b/guide/functions.md
@@ -1,5 +1,4 @@
-Functions in FTL
-================
+# Functions in FTL
 
 Functions provide additional functionality available to the localizers. They
 can be either used to format data according to the current language's rules or
@@ -9,23 +8,22 @@ time of the day) to fine tune the translation.
 FTL implementations should ship with a number of built-in functions that can be
 used from within localization messages.
 
-The list of available functions is extensible and environments may want to add
-additional functions designated to aid localizers writing translations targeted
-for a given environment.
+The list of available functions is extensible and environments may want to
+introduce additional functions, designed to aid localizers writing translations
+targeted for such environments.
 
-Using Functions
----------------
+## Using Functions
 
 FTL Functions can only be called inside of placeables. Use them to return
 a value to be interpolated in the message or as selectors in select
 expressions.
 
 Example:
+```
+today-is = Today is { DATETIME($date) }
+```
 
-    today-is = Today is { DATETIME($date) }
-
-Function parameters
--------------------
+## Function parameters
 
 Functions may (but don't have to) accept positional and keyword arguments. Some
 keyword parameters are only available to developers and cannot be used inside
@@ -35,8 +33,7 @@ translations by the developer.
 See the reference below for more information about the arguments accepted for
 each built-in function.
 
-Built-in Functions
-------------------
+## Built-in Functions
 
 Built-in functions are very generic and should be applicable to any translation
 environment.
@@ -46,23 +43,26 @@ environment.
 Formats a number to a string in a given locale.
 
 Example:
-
-    dpi-ratio = Your DPI ratio is { NUMBER($ratio, minimumFractionDigits: 2) }
+```
+dpi-ratio = Your DPI ratio is { NUMBER($ratio, minimumFractionDigits: 2) }
+```
 
 Parameters:
-
-    currencyDisplay
-    useGrouping
-    minimumIntegerDigits
-    minimumFractionDigits
-    maximumFractionDigits
-    minimumSignificantDigits
-    maximumSignificantDigits
+```
+currencyDisplay
+useGrouping
+minimumIntegerDigits
+minimumFractionDigits
+maximumFractionDigits
+minimumSignificantDigits
+maximumSignificantDigits
+```
 
 Developer parameters:
-
-    style
-    currency
+```
+style
+currency
+```
 
 See the
 [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)
@@ -73,30 +73,32 @@ for the description of the parameters.
 Formats a date to a string in a given locale.
 
 Example:
-
-    today-is = Today is { DATETIME($date, month: "long", year: "numeric", day: "numeric") }
+```
+today-is = Today is { DATETIME($date, month: "long", year: "numeric", day: "numeric") }
+```
 
 Parameters:
-
-    hour12
-    weekday
-    era
-    year
-    month
-    day
-    hour
-    minute
-    second
-    timeZoneName
+```
+hour12
+weekday
+era
+year
+month
+day
+hour
+minute
+second
+timeZoneName
+```
 
 Developer parameters:
-
-    timeZone
+```
+timeZone
+```
 
 See the [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) for the description of the parameters.
 
-Implicit use
-------------
+## Implicit use
 
 In order to simplify most common scenarios, FTL will run some default functions
 while resolving placeables.
@@ -107,13 +109,14 @@ If the variable passed from the developer is a number and is used in
 a placeable, FTL will implicitly call a NUMBER function on it.
 
 Example:
+```
+emails = Number of unread emails { $unreadEmails }
 
-    emails = Number of unread emails { $unreadEmails }
-
-    emails2 = Number of unread emails { NUMBER($undeadEmails) }
+emails2 = Number of unread emails { NUMBER($undeadEmails) }
+```
 
 Numbers used as selectors in select expressions will match the number exactly
-of they will match the current language's [CLDR plural
+or they will match the current language's [CLDR plural
 category](http://www.unicode.org/cldr/charts/30/supplemental/language_plural_rules.html)
 for the number.
 
@@ -121,17 +124,19 @@ The following examples are equivalent and will both work. The second example
 may be used to pass additional formatting options to the `NUMBER` formatter for
 the purpose of choosing the correct plural category:
 
-    liked-count = { $num ->
-      [0]     No likes yet.
-      [one]   One person liked your message
-     *[other] { $num } people liked your message
-    }
+```
+liked-count = { $num ->
+  [0]     No likes yet.
+  [one]   One person liked your message
+ *[other] { $num } people liked your message
+}
 
-    liked-count2 = { NUMBER($num) ->
-      [0]     No likes yet.
-      [one]   One person liked your message
-     *[other] { $num } people liked your message
-    }
+liked-count2 = { NUMBER($num) ->
+  [0]     No likes yet.
+  [one]   One person liked your message
+ *[other] { $num } people liked your message
+}
+```
 
 ### `DATETIME`  
 
@@ -139,13 +144,13 @@ If the variable passed from the developer is a date and is used in a placeable,
 FTL will implicitly call a DATE function on it.
 
 Example:
+```
+log-time = Entry time: { $date }
 
-    log-time = Entry time: { $date }
+log-time2 = Entry time: { DATETIME($date) }
+```
 
-    log-time2 = Entry time: { DATETIME($date) }
-
-Partial arguments
------------------
+## Partial arguments
 
 In most cases users will not have to call out Function explicitly, thanks to
 the implicit calls.
@@ -171,10 +176,9 @@ let str = ctx.format('key1', {
 key1 = Today is { $day }
 ```
 
-If the localizer decide that they have to modify the parameters, for example
+If the localizer decides that they have to modify the parameters, for example
 because the string doesn't fit in the UI, they can pass the variable to the
 same Function and overload parameters. Example:
 ```
 key1 = Today is { DATETIME($day, weekday: "short") }
-
 ```

--- a/guide/hello.md
+++ b/guide/hello.md
@@ -1,5 +1,4 @@
-Hello World
------------
+# Hello World
 
 In Fluent, the basic unit of translation is called a message.
 The simplest example of a message looks like this:
@@ -12,7 +11,7 @@ Messages are containers for information. You use messages to identify, store,
 and recall translation information to be used in the software's UI.
 
 Each message has an identifier that allows the developer to bind it to the place
-in the software where it will be used. The above message is called `hello`. 
+in the software where it will be used. The above message is called `hello`.
 
 In its simplest form, a message has just a single string value; here *Hello,
 World!*. Most of the messages you will work with in Fluent will look similar to

--- a/guide/more.md
+++ b/guide/more.md
@@ -1,5 +1,4 @@
-Dive deeper
------------
+# Dive deeper
 
 You can experiment with the syntax using [Fluent Playground][], an interactive
 editor available in the web browser.

--- a/guide/references.md
+++ b/guide/references.md
@@ -1,12 +1,11 @@
-Message References
-------------------
+# Message References
+
 ```
 brandName = Loki
 installing = Installing { brandName }.
 
 menu-save = Save
 help-menu-save = Click "{ menu-save }" to save the file.
-
 ```
 
 Strings in FTL may use special syntax to incorporate small pieces of

--- a/guide/sections.md
+++ b/guide/sections.md
@@ -1,5 +1,5 @@
-Sections
---------
+# Sections
+
 ```
 instruction = Click "{ open }" to begin
 

--- a/guide/selectors.md
+++ b/guide/selectors.md
@@ -1,11 +1,10 @@
-Selectors
----------
+# Selectors
+
 ```
 emails = { $unreadEmails ->
     [one] You have one unread email.
    *[other] You have { $unreadEmails } unread emails.
 }
-
 ```
 
 ```json
@@ -19,21 +18,23 @@ there are multiple variants of the string that depend on some external
 argument. FTL provides the select expression syntax, which chooses one of the
 provided variants based on the given selector.
 
-The selector may be a string in which case it will be compared directly to the
+The selector may be a string, in which case it will be compared directly to the
 keys of variants defined in the select expression. For number selectors, the
 variant keys either match the number exactly or they match the [CLDR plural
 category](http://www.unicode.org/cldr/charts/30/supplemental/language_plural_rules.html)
 for the number. The possible categories are: `zero`, `one`, `two`, `few`,
-`many` and `other`. For instance, English has two plural categories: `one` and
+`many`, and `other`. For instance, English has two plural categories: `one` and
 `other`.
 
 If the translation requires a number to be formatted in a particular
 non-default manner, the selector should use the same formatting options. The
 formatted number will then be used to choose the correct CLDR plural category
-which for some languages might be different than the category of the
+which, for some languages, might be different than the category of the
 unformatted number:
 
-    your-score = { NUMBER($score, minimumFractionDigits: 1) ->
-        [0.0]   You scored zero points. What happened?
-       *[other] You scored { NUMBER($score, minimumFractionDigits: 1) } points.
-    }
+```
+your-score = { NUMBER($score, minimumFractionDigits: 1) ->
+    [0.0]   You scored zero points. What happened?
+   *[other] You scored { NUMBER($score, minimumFractionDigits: 1) } points.
+}
+```

--- a/guide/text.md
+++ b/guide/text.md
@@ -1,5 +1,5 @@
-Working With Text: Multiline, Quote Delimited Strings
------------------------------------------------------
+# Working With Text: Multiline, Quote Delimited Strings
+
 ```
 about = About Our Software
 description =

--- a/guide/variants.md
+++ b/guide/variants.md
@@ -1,5 +1,5 @@
-Variants
---------
+# Variants
+
 ```
 brand-name = {
    *[nominative] Aurora
@@ -11,14 +11,13 @@ brand-name = {
 }
 
 about = O { brand-name[locative] }
-
 ```
 
-As we stated at the beginning of this guide, messages primarely consist of
+As we stated at the beginning of this guide, messages primarily consist of
 string values. A single string value can have multiple branches, or variants,
 which are chosen based on the value of a selector. In some cases, however, we
 don't need any selector and instead just want to define multiple variants of
-the message and use them from within other messages. For instance. in languages
+the message and use them from within other messages. For instance, in languages
 that use noun declension, `brand-name` may need to be declined when referred to
 from other messages.
 
@@ -27,7 +26,6 @@ same message. You can refer to them using the `message[variant key]` syntax.
 
 For instance, in many inflected languages (e.g. German, Finnish, Hungarian, all
 Slavic languages), the *about* preposition governs the grammatical case of the
-complement. It might be the accusative (German), the ablative (Latin) or the
-locative (Slavic languages). The grammatical cases can be defined as variants
-without a selector and referred to from other messages, like the `about`
-message above.
+complement. It might be accusative (German), ablative (Latin), or locative
+(Slavic languages). The grammatical cases can be defined as variants without a
+selector and referred to from other messages, like the `about` message above.

--- a/syntax/README.md
+++ b/syntax/README.md
@@ -1,11 +1,10 @@
-Fluent Syntax (FTL)
-===================
+# Fluent Syntax (FTL)
 
-_Version 0.2.0._
+## Version 0.2.0
 
 Specification, design and documentation for FTL, the syntax for describing
-translation resources in Project Fluent.  FTL stands for _Fluent Translation
-List_.
+translation resources in Project Fluent.  FTL stands for *Fluent Translation
+List*.
 
 Read the [Fluent Syntax Guide][].
 


### PR DESCRIPTION
Since you’re using third level titles in some docs, I think it makes sense to stick to the hash syntax.

Also, use code blocks and not blockquotes for code, h1 for the main title of the doc instead of h2