### PR TITLE
Change Annotation to { code, args, message, span }

### DIFF
--- a/spec/fluent.asdl
+++ b/spec/fluent.asdl
@@ -31,7 +31,7 @@ module Fluent
           | Junk(str content)
           attributes (annot* annotations, span span)
 
-    annot = Annotation(str name, str message, int pos)
+    annot = Annotation(str code, str* args, str message, span span)
     span = Span(int start, int end)
 
     -- Pattern values


### PR DESCRIPTION
Annotations will now have unique codes: E0000 for errors, W0000 for warnings
and H0000 for hints.  They also now have a span, similar to Entries.  If an
annotation is only related to a single position in the file, the Span's start
and end field should be equal.