### PR TITLE
Define the behavior of backslash escapes

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -7,9 +7,7 @@ comment              ::= ('//' (char - NL)* )+
 section              ::= '[[' _? word (_ word)* _? ']]'
 
 char                 ::= [https://www.w3.org/TR/REC-xml/#NT-Char]
-
-/* special chars: { } [ \ ] */
-special              ::= [#x5b#x5c#x5d#x7b#x7d]
+hexdigit             ::= [0-9a-fA-F]
 
 /* line feed, carriage return; space, tab */
 line-break           ::= [#xA#xD]+
@@ -24,7 +22,9 @@ __                   ::= break-indent
 
 identifier           ::= [a-zA-Z_?-] [a-zA-Z0-9_?-]*
 external             ::= '$' identifier
-word                 ::= (((char - line-break) - inline-space) - special)+
+
+/* exclude whitespace and [ \ ] { } */
+word                 ::= (((char - line-break) - inline-space) - [#x5b#x5c#x5d#x7b#x7d])+
 builtin              ::= [A-Z_?-]+
 number               ::= '-'? [0-9]+ ('.' [0-9]+)?
 
@@ -43,8 +43,16 @@ attribute-list       ::= attribute+
 message              ::= identifier ((value tag-list?) | (value? attribute-list))
 value                ::= _? '=' __? pattern
 pattern              ::= (text | placeable)+
-text                 ::= ((char - line-break) - special | break-indent | '\' special)+
-quoted-text          ::= '"' (text | '\"')+ '"'
+/* text can only include newlines if they're followed by an indent */
+/* \ and { must be escaped */
+text-char            ::= (char - line-break) - [#x5c#x7b]
+                       | break-indent
+                       | '\u' hexdigit hexdigit hexdigit hexdigit
+                       | '\' [#x5c#x7b]
+text                 ::= text-char+
+/* in quoted-text " must be escaped */
+quoted-text          ::= '"' (text-char - '"' | '\"')+ '"'
+
 
 placeable            ::= '{' __? (expression | select-expression | variant-list) __? '}'
 expression           ::= quoted-text


### PR DESCRIPTION
This PR is based on the comment in https://github.com/projectfluent/fluent/issues/22#issuecomment-292591531. To recap:

  - Escape sequences are only allowed in `text` and `quoted-text`.
  - Newlines are preserved by the parser. This allows proper serialization.
  - Known escape sequences are: `\\` for the literal backslash, `\"` for the literal double quote, `\{` for the literal opening brace and `\u` followed by 4 hex digits for Unicode code points. Representing code points from outside of the Basic Multilingual Plane is made possible with surrogate pairs (two `\uXXXX` sequences). Using the actual character is encouraged, however.
  - Any other escaped characters result in a parsing error. (We might relax this to producing warnings and parsing to a space for instance, but let's start with a stricter approach.)