### PR TITLE
Add an intermediate Placeable production for Expressions within Patterns

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
-  - …
+  - Added the `Placeable` production as a wrapper for expressions in patterns.
+
+    This allows storing more precise information about the whitespace around
+    the placeable's braces.
+
+  - Separated the `expr` type into `inline_expr` and `block_expr`.
+
+    This mirrors the EBNF, where a select expression cannot by an argument to
+    a call expression nor selector of another select expression without being
+    wrapped in braces.
 
 ## 0.3.0
 

--- a/spec/fluent.asdl
+++ b/spec/fluent.asdl
@@ -37,19 +37,22 @@ module Fluent
     -- Pattern values
     pat = Pattern(elem* elements, span? span)
     elem = TextElement(string value, span? span)
-         | Expression(expr)
+         | Placeable(expr expression, span? span)
 
     -- Expressions
-    expr = StringExpression(string)
-         | NumberExpression(number)
-         | MessageReference(iden id)
-         | ExternalArgument(iden id)
-         | SelectExpression(expr? expression, var* variants)
-         | AttributeExpression(iden id, iden name)
-         | VariantExpression(iden id, varkey key)
-         | CallExpression(fun callee, arg* arguments)
-         | Expression(expr)
-         attributes (span? span)
+    expr = InlineExpression(inline_expr)
+         | BlockExpression(block_expr)
+    inline_expr = StringExpression(string)
+                | NumberExpression(number)
+                | MessageReference(iden id)
+                | ExternalArgument(iden id)
+                | AttributeExpression(iden id, iden name)
+                | VariantExpression(iden id, varkey key)
+                | CallExpression(fun callee, arg* arguments)
+                | Placeable(expr expression)
+                attributes (span? span)
+    block_expr = SelectExpression(inline_expr? expression, var* variants)
+               attributes (span? span)
 
     -- Attributes of Message
     attr = Attribute(iden id, pat value, span? span)
@@ -63,7 +66,7 @@ module Fluent
            | Symbol(symb)
 
     -- Arguments to CallExpression
-    arg = Expression(expr)
+    arg = Expression(inline_expr)
         | NamedArgument(iden name, argval value, span? span)
     argval = NumberExpression(number)
            | StringExpression(string)

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -54,8 +54,9 @@ text                 ::= text-char+
 quoted-text          ::= '"' (text-char - '"' | '\"')+ '"'
 
 
-placeable            ::= '{' __? (expression | select-expression | variant-list) __? '}'
-expression           ::= quoted-text
+placeable            ::= '{' __? (inline-expression | block-expression) __? '}'
+
+inline-expression    ::= quoted-text
                        | number
                        | identifier
                        | external
@@ -63,11 +64,13 @@ expression           ::= quoted-text
                        | variant-expression
                        | call-expression
                        | placeable
+block-expression     ::= select-expression
+                       | variant-list
 
-select-expression    ::= expression __ '->' __ variant-list
+select-expression    ::= inline-expression __ '->' __ variant-list
 attribute-expression ::= identifier '.' identifier
 variant-expression   ::= identifier '[' _? variant-key _? ']'
 call-expression      ::= builtin '(' __? (argument ( __? ',' __? argument)*)? __? ')'
-argument             ::= expression
+argument             ::= inline-expression
                        | named-argument
 named-argument       ::= identifier __? ':' __? (quoted-text | number)


### PR DESCRIPTION
Fixes #47.

Added the `Placeable` production as a wrapper for expressions in
patterns.  This allows storing more precise information about the
whitespace around the placeable's braces.

Separated the `expr` type into `inline_expr` and `block_expr`.  This
mirrors the EBNF, where a select expression cannot by an argument to
a call expression nor selector of another select expression without
being wrapped in braces.