### PR TITLE
Allow multiline comments

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -3,7 +3,7 @@ entry                ::= comment
                        | section
                        | message
 
-comment              ::= ('//' (char - NL)* )+
+comment              ::= ('//' (char - NL)* NL)+
 section              ::= '[[' _? word (_ word)* _? ']]'
 
 char                 ::= [https://www.w3.org/TR/REC-xml/#NT-Char]


### PR DESCRIPTION
The EBNF didn't allow comments to be multiline. This was reported in #36
and a fix was proposed there as well, but never landed.