### PR TITLE
Fix #65. Forbid ? in identifiers.

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -21,7 +21,7 @@ _                    ::= inline-space
 NL                   ::= line-break
 __                   ::= break-indent
 
-identifier           ::= [a-zA-Z] [a-zA-Z0-9_?-]*
+identifier           ::= [a-zA-Z] [a-zA-Z0-9_-]*
 external             ::= '$' identifier
 
 /* exclude whitespace and [ \ ] { } */


### PR DESCRIPTION
Fix #65. We're going back on this.  Let's start without it and revisit post-1.0.