### PR TITLE
Streamline the ASDL for Messages

### DIFF
--- a/spec/fluent.asdl
+++ b/spec/fluent.asdl
@@ -25,15 +25,13 @@ module Fluent
 {
     res = Resource(entry* body, comment? comment, span? span)
 
-    entry = BaseMessage(base_message)
+    entry = Message(message)
           | Section(symb name, comment? comment)
           | Comment(comment)
           | Junk(str content)
           attributes (annot* annotations, span? span)
 
-    base_message = Message
-                 | PrivateMessage
-                 attributes (iden id, pat? value, attr* attributes, comment? comment)
+    message = Message(iden id, pat? value, attr* attributes, comment? comment)
 
     annot = Annotation(str code, str* args, str message, span? span)
     span = Span(int start, int end)


### PR DESCRIPTION
We can rely on checking the first character of the identifier to detect private messages.

In the runtime, we only need this check to forbid retrieving private messages via `MessageContext.getMessage`. All other use-cases are eagerly handled in the parsing and result in syntax errors.