### PR TITLE
Revert #74 - Syntax sugar for block expression values

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -42,7 +42,7 @@ attribute-list       ::= attribute+
 message              ::= public-identifier ((value attribute-list?) | (value? attribute-list))
                        | private-identifier value attribute-list?
 
-value                ::= _? '=' (__? pattern | _? '{' __? block-expression blank-line* '}')
+value                ::= _? '=' __? pattern
 pattern              ::= (text | placeable)+
 /* text can only include newlines if they're followed by an indent */
 /* \ and { must be escaped */


### PR DESCRIPTION
The block expression syntax sugar discussed in #42  and introduced in #74 allowed the closing brace of a block expression which is the only placeable in the pattern to be on the first column of the line, without indentation. Requiring the closing `}` to be indented had been reported as a papercut.

```properties
foo = {
   *[nominative] Foo
    [genitive] Foo's
}
```

The above syntax is desired and more intuitive and we'll try to make it possible in the future along with other changes relaxing the indentation requirement. For now, the block expression sugar can be surprising and it creates a false expectation that the closing `}` doesn't need to be indented.

It also creates a refactoring hazard: factoring a common part of the translation out of a block expression results in a syntax error:

```properties
# This is OK: the block expression is the only element in the Pattern.
new-messages = { $num ->
    [one] New message
   *[other] New messages
}

# Syntax Error at "}".
new-messages = New { $num ->
    [one] message
   *[other] messages
}
```

For the time being, the recommended formatting of block expression is to indent the entire body of the message:

```properties
new-messages =
    { $num ->
        [one] New message
       *[other] New messages
    }
```