### PR TITLE
Don't swallow exceptions in Parser.run

### DIFF
--- a/lib/parser.mjs
+++ b/lib/parser.mjs
@@ -13,15 +13,10 @@ export default class Parser {
     }
 
     run(iterable) {
-        const stream = iterable instanceof Stream
+        let stream = iterable instanceof Stream
             ? iterable
             : new Stream(iterable);
-        try {
-            return this.parse(stream);
-        } catch (err) {
-            // console.error(err.message);
-            return new Failure(err.message, stream);
-        }
+        return this.parse(stream);
     }
 
     get abstract() {

--- a/lib/stream.mjs
+++ b/lib/stream.mjs
@@ -7,10 +7,10 @@ export default class Stream {
             : length;
     }
 
-    // Get the first value from the iterable.
+    // Get the element at the cursor.
     head() {
         if (this.length < 0) {
-            throw new TypeError("index out of range");
+            return undefined;
         }
 
         if (this.length === 0) {

--- a/test/fixtures/eof_comment.ftl
+++ b/test/fixtures/eof_comment.ftl
@@ -1,0 +1,3 @@
+### NOTE: Disable final newline insertion when editing this file.
+
+# No EOL

--- a/test/fixtures/eof_comment.json
+++ b/test/fixtures/eof_comment.json
@@ -1,0 +1,15 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "ResourceComment",
+            "annotations": [],
+            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+        },
+        {
+            "type": "Comment",
+            "annotations": [],
+            "content": "No EOL"
+        }
+    ]
+}

--- a/test/fixtures/eof_empty.json
+++ b/test/fixtures/eof_empty.json
@@ -1,0 +1,4 @@
+{
+    "type": "Resource",
+    "body": []
+}

--- a/test/fixtures/eof_id.ftl
+++ b/test/fixtures/eof_id.ftl
@@ -1,0 +1,3 @@
+### NOTE: Disable final newline insertion when editing this file.
+
+message-id

--- a/test/fixtures/eof_id.json
+++ b/test/fixtures/eof_id.json
@@ -1,0 +1,15 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "ResourceComment",
+            "annotations": [],
+            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "message-id"
+        }
+    ]
+}

--- a/test/fixtures/eof_id_equals.ftl
+++ b/test/fixtures/eof_id_equals.ftl
@@ -1,0 +1,3 @@
+### NOTE: Disable final newline insertion when editing this file.
+
+message-id =

--- a/test/fixtures/eof_id_equals.json
+++ b/test/fixtures/eof_id_equals.json
@@ -1,0 +1,15 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "ResourceComment",
+            "annotations": [],
+            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "message-id ="
+        }
+    ]
+}

--- a/test/fixtures/eof_junk.ftl
+++ b/test/fixtures/eof_junk.ftl
@@ -1,0 +1,3 @@
+### NOTE: Disable final newline insertion when editing this file.
+
+000

--- a/test/fixtures/eof_junk.json
+++ b/test/fixtures/eof_junk.json
@@ -1,0 +1,15 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "ResourceComment",
+            "annotations": [],
+            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "000"
+        }
+    ]
+}

--- a/test/fixtures/eof_value.ftl
+++ b/test/fixtures/eof_value.ftl
@@ -1,0 +1,3 @@
+### NOTE: Disable final newline insertion when editing this file.
+
+no-eol = No EOL

--- a/test/fixtures/eof_value.json
+++ b/test/fixtures/eof_value.json
@@ -1,0 +1,29 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "ResourceComment",
+            "annotations": [],
+            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+        },
+        {
+            "type": "Message",
+            "annotations": [],
+            "id": {
+                "type": "Identifier",
+                "name": "no-eol"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "No EOL"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        }
+    ]
+}


### PR DESCRIPTION
I was writing a [quick guide to debugging the refparser](https://github.com/projectfluent/fluent/wiki/Debugging-the-Reference-Parser) and I realized there was a `try catch` which made things unnecessary hard to debug.

Also, this adds a few fixtures for testing the missing final newline.