### PR TITLE
Add TermReference expressions

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -43,6 +43,11 @@
     positional first, named second. The `CallExpression`'s `arguments` field
     was replaced by two new fields: `positional` and `named`.
 
+  - Added the `TermReference` expression.
+
+    References to terms used to be stored as `MessageReferences` in the AST.
+    They now have their own expression type.
+
 ## 0.5.0 (January 31, 2018)
 
   - Added terms. (#62, #85)

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -32,13 +32,15 @@ InlineExpression           ::= StringExpression
                              | CallExpression
                              | MessageAttributeExpression
                              | TermVariantExpression
-                             | Identifier
-                             | TermIdentifier
+                             | MessageReference
+                             | TermReference
                              | Placeable
 
 /* Inline Expressions */
 StringExpression           ::= quoted_text
 NumberExpression           ::= number
+MessageReference           ::= Identifier
+TermReference              ::= TermIdentifier
 ExternalArgument           ::= ExternalIdentifier
 CallExpression             ::= Function "(" space_indent? argument_list space_indent? ")"
 argument_list              ::= (Argument space_indent? "," space_indent?)* Argument?

--- a/syntax/ast.mjs
+++ b/syntax/ast.mjs
@@ -111,6 +111,14 @@ export class MessageReference extends Expression {
     }
 }
 
+export class TermReference extends Expression {
+    constructor(id) {
+        super();
+        this.type = "TermReference";
+        this.id = id;
+    }
+}
+
 export class ExternalArgument extends Expression {
     constructor(id) {
         super();

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -168,8 +168,8 @@ let InlineExpression = defer(() =>
         CallExpression, // Must be before MessageReference
         MessageAttributeExpression,
         TermVariantExpression,
-        Identifier.chain(into(FTL.MessageReference)),
-        TermIdentifier.chain(into(FTL.MessageReference)),
+        MessageReference,
+        TermReference,
         Placeable));
 
 /* ------------------ */
@@ -179,6 +179,12 @@ let StringExpression = defer(() =>
 
 let NumberExpression = defer(() =>
     number.chain(into(FTL.NumberExpression)));
+
+let MessageReference = defer(() =>
+    Identifier.chain(into(FTL.MessageReference)));
+
+let TermReference = defer(() =>
+    TermIdentifier.chain(into(FTL.TermReference)));
 
 let ExternalArgument = defer(() =>
     ExternalIdentifier.chain(into(FTL.ExternalArgument)));

--- a/test/fixtures/reference_expressions.json
+++ b/test/fixtures/reference_expressions.json
@@ -39,7 +39,7 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "MessageReference",
+                            "type": "TermReference",
                             "id": {
                                 "type": "Identifier",
                                 "name": "-term"


### PR DESCRIPTION
References to terms are currently stored as `MessageReferences` in the AST. This PR adds a new expression type for them, called `TermReference`.

Fixes #95.