### PR TITLE
Store the referent expression in attribute and variant expressions

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -48,6 +48,12 @@
     References to terms used to be stored as `MessageReferences` in the AST.
     They now have their own expression type.
 
+  - Store the referent expression in attribute and variant expressions.
+
+    `MessageAttributeExpression`, `TermAttributeExpression` and
+    `TermVariantExpression` now store the entire referent expression in a new
+    `ref` field, rather than just the `Identifier`.
+
 ## 0.5.0 (January 31, 2018)
 
   - Added terms. (#62, #85)

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -47,8 +47,8 @@ argument_list              ::= (Argument space_indent? "," space_indent?)* Argum
 Argument                   ::= NamedArgument
                              | InlineExpression
 NamedArgument              ::= Identifier space_indent? ":" space_indent? (StringExpression | NumberExpression)
-MessageAttributeExpression ::= Identifier "." Identifier
-TermVariantExpression      ::= TermIdentifier VariantKey
+MessageAttributeExpression ::= MessageReference "." Identifier
+TermVariantExpression      ::= TermReference VariantKey
 
 /* Block Expressions */
 SelectExpression           ::= SelectorExpression inline_space? "->" inline_space? variant_list break_indent
@@ -57,7 +57,7 @@ SelectorExpression         ::= StringExpression
                              | ExternalArgument
                              | CallExpression
                              | TermAttributeExpression
-TermAttributeExpression    ::= TermIdentifier "." Identifier
+TermAttributeExpression    ::= TermReference "." Identifier
 VariantList                ::= variant_list break_indent
 variant_list               ::= Variant* DefaultVariant Variant*
 Variant                    ::= break_indent VariantKey inline_space? Pattern

--- a/syntax/ast.mjs
+++ b/syntax/ast.mjs
@@ -137,19 +137,19 @@ export class SelectExpression extends Expression {
 }
 
 export class AttributeExpression extends Expression {
-    constructor(id, name) {
+    constructor(ref, name) {
         super();
         this.type = "AttributeExpression";
-        this.id = id;
+        this.ref = ref;
         this.name = name;
     }
 }
 
 export class VariantExpression extends Expression {
-    constructor(id, key) {
+    constructor(ref, key) {
         super();
         this.type = "VariantExpression";
-        this.id = id;
+        this.ref = ref;
         this.key = key;
     }
 }

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -231,7 +231,7 @@ let NamedArgument = defer(() =>
 
 let MessageAttributeExpression = defer(() =>
     sequence(
-        Identifier.abstract,
+        MessageReference.abstract,
         char("."),
         Identifier.abstract)
     .map(keep_abstract)
@@ -239,7 +239,7 @@ let MessageAttributeExpression = defer(() =>
 
 let TermVariantExpression = defer(() =>
     sequence(
-        TermIdentifier.abstract,
+        TermReference.abstract,
         VariantKey.abstract)
     .map(keep_abstract)
     .chain(list_into(FTL.VariantExpression)));
@@ -267,7 +267,7 @@ let SelectorExpression = defer(() =>
 
 let TermAttributeExpression = defer(() =>
     sequence(
-        TermIdentifier.abstract,
+        TermReference.abstract,
         char("."),
         Identifier.abstract)
     .map(keep_abstract)

--- a/test/fixtures/member_expressions.json
+++ b/test/fixtures/member_expressions.json
@@ -15,9 +15,12 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "VariantExpression",
-                            "id": {
-                                "type": "Identifier",
-                                "name": "-term"
+                            "ref": {
+                                "type": "TermReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "-term"
+                                }
                             },
                             "key": {
                                 "type": "VariantName",
@@ -44,9 +47,12 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "AttributeExpression",
-                            "id": {
-                                "type": "Identifier",
-                                "name": "msg"
+                            "ref": {
+                                "type": "MessageReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "msg"
+                                }
                             },
                             "name": {
                                 "type": "Identifier",

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -90,9 +90,12 @@
                             "type": "SelectExpression",
                             "selector": {
                                 "type": "AttributeExpression",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "-term"
+                                "ref": {
+                                    "type": "TermReference",
+                                    "id": {
+                                        "type": "Identifier",
+                                        "name": "-term"
+                                    }
                                 },
                                 "name": {
                                     "type": "Identifier",


### PR DESCRIPTION
Make `MessageAttributeExpression`, `TermAttributeExpression` and `TermVariantExpression` store the entire referent expression in a new `ref` field, rather than just the `Identifier`.

Fixes #120.