### PR TITLE
Introduce the VariantList value type

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -56,6 +56,16 @@
 
   - `ExternalArgument` is now called `VariableReference`.
 
+  - Add the `VariantList` value type.
+
+    Selector-less `SelectExpressions` have been removed in favor of
+    `VariantLists` which share the same syntax but have more restricted usage.
+    Values of `Messages` and all `Attributes` may only be `Patterns`.  Values
+    of `Terms` may either be `Patterns` or `VariantLists`.  Values of
+    `Variants` may only be `VariantLists` if they're defined in another
+    `VariantList`.
+
+
 ## 0.5.0 (January 31, 2018)
 
   - Added terms. (#62, #85)

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -5,7 +5,7 @@ Entry                      ::= Message
                              | Term
                              | (ResourceComment | GroupComment | Comment)
 Message                    ::= Comment? Identifier inline_space? "=" inline_space? ((Pattern Attribute*) | (Attribute+)) line_end
-Term                       ::= Comment? TermIdentifier inline_space? "=" inline_space? Pattern Attribute* line_end
+Term                       ::= Comment? TermIdentifier inline_space? "=" inline_space? Value Attribute* line_end
 Comment                    ::= ("#" comment_line)+
 GroupComment               ::= ("##" comment_line)+
 ResourceComment            ::= ("###" comment_line)+
@@ -17,15 +17,16 @@ junk_line                  ::= /.*/ line_end
 /* Attributes of Messages and Terms. */
 Attribute                  ::= break_indent "." Identifier inline_space? "=" inline_space? Pattern
 
-/* Patterns consist of TextElements or Placeables. */
+/* Value types: Pattern and VariantList. */
+Value                      ::= Pattern
+                             | VariantList
 Pattern                    ::= PatternElement+
+VariantList                ::= space_indent? "{" variant_list "}"
 PatternElement             ::= TextElement
                              | Placeable
                              | (break_indent Placeable)
 TextElement                ::= (text_char | text_cont)+
-Placeable                  ::= "{" inline_space? (BlockExpression | InlineExpression) inline_space? "}"
-BlockExpression            ::= SelectExpression
-                             | VariantList
+Placeable                  ::= "{" inline_space? (SelectExpression | InlineExpression) inline_space? "}"
 InlineExpression           ::= StringExpression
                              | NumberExpression
                              | VariableReference
@@ -51,17 +52,16 @@ MessageAttributeExpression ::= MessageReference "." Identifier
 TermVariantExpression      ::= TermReference VariantKey
 
 /* Block Expressions */
-SelectExpression           ::= SelectorExpression inline_space? "->" inline_space? variant_list break_indent
+SelectExpression           ::= SelectorExpression inline_space? "->" variant_list
 SelectorExpression         ::= StringExpression
                              | NumberExpression
                              | VariableReference
                              | CallExpression
                              | TermAttributeExpression
 TermAttributeExpression    ::= TermReference "." Identifier
-VariantList                ::= variant_list break_indent
-variant_list               ::= Variant* DefaultVariant Variant*
-Variant                    ::= break_indent VariantKey inline_space? Pattern
-DefaultVariant             ::= break_indent "*" VariantKey inline_space? Pattern
+variant_list               ::= inline_space? Variant* DefaultVariant Variant* break_indent
+Variant                    ::= break_indent VariantKey inline_space? Value
+DefaultVariant             ::= break_indent "*" VariantKey inline_space? Value
 VariantKey                 ::= "[" inline_space? (NumberExpression | VariantName) inline_space? "]"
 VariantName                ::= word (inline_space word)*
 

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -36,9 +36,23 @@ export function list_into(Type) {
                     entries
                         .reduce(join_adjacent(FTL.Junk), [])
                         .filter(remove_blank_lines)));
+        case FTL.SelectExpression:
+            return ([selector, variants]) => {
+                let invalid_variants_found = variants.some(
+                    variant => variant.value instanceof FTL.VariantList);
+                if (invalid_variants_found) {
+                    return never(
+                        "VariantLists are only allowed inside of " +
+                        "other VariantLists.");
+                }
+                return always(new Type(selector, variants));
+            };
         case FTL.Term:
             return ([comment, ...args]) =>
                 always(new Type(...args, comment));
+        case FTL.VariantList:
+            return ([variants]) =>
+                always(new Type(variants));
         default:
             return elements =>
                 always(new Type(...elements));

--- a/syntax/ast.mjs
+++ b/syntax/ast.mjs
@@ -56,6 +56,14 @@ export class Term extends Entry {
     }
 }
 
+export class VariantList extends SyntaxNode {
+    constructor(variants) {
+        super();
+        this.type = "VariantList";
+        this.variants = variants;
+    }
+}
+
 export class Pattern extends SyntaxNode {
     constructor(elements) {
         super();

--- a/test/fixtures/select_expressions.ftl
+++ b/test/fixtures/select_expressions.ftl
@@ -9,17 +9,28 @@ valid-selector =
        *[    many     words    ] value
     }
 
+# ERROR
 invalid-selector =
     { -term[case] ->
-       *[key] value
-    }
-
-variant-list =
-    {
        *[key] value
     }
 
 empty-variant =
     { 1 ->
        *[one] {""}
+    }
+
+nested-select =
+    { 1 ->
+       *[one] { 2 ->
+          *[two] Value
+       }
+    }
+
+# ERROR VariantLists cannot appear in SelectExpressions
+nested-variant-list =
+    { 1 ->
+       *[one] {
+          *[two] Value
+       }
     }

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -129,50 +129,14 @@
             "comment": null
         },
         {
+            "type": "Comment",
+            "annotations": [],
+            "content": "ERROR\n"
+        },
+        {
             "type": "Junk",
             "annotations": [],
             "content": "invalid-selector =\n    { -term[case] ->\n       *[key] value\n    }\n"
-        },
-        {
-            "type": "Message",
-            "annotations": [],
-            "id": {
-                "type": "Identifier",
-                "name": "variant-list"
-            },
-            "value": {
-                "type": "Pattern",
-                "elements": [
-                    {
-                        "type": "Placeable",
-                        "expression": {
-                            "type": "SelectExpression",
-                            "selector": null,
-                            "variants": [
-                                {
-                                    "type": "Variant",
-                                    "key": {
-                                        "type": "VariantName",
-                                        "name": "key"
-                                    },
-                                    "value": {
-                                        "type": "Pattern",
-                                        "elements": [
-                                            {
-                                                "type": "TextElement",
-                                                "value": "value"
-                                            }
-                                        ]
-                                    },
-                                    "default": true
-                                }
-                            ]
-                        }
-                    }
-                ]
-            },
-            "attributes": [],
-            "comment": null
         },
         {
             "type": "Message",
@@ -220,6 +184,85 @@
             },
             "attributes": [],
             "comment": null
+        },
+        {
+            "type": "Message",
+            "annotations": [],
+            "id": {
+                "type": "Identifier",
+                "name": "nested-select"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "NumberExpression",
+                                "value": "1"
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "VariantName",
+                                        "name": "one"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "Placeable",
+                                                "expression": {
+                                                    "type": "SelectExpression",
+                                                    "selector": {
+                                                        "type": "NumberExpression",
+                                                        "value": "2"
+                                                    },
+                                                    "variants": [
+                                                        {
+                                                            "type": "Variant",
+                                                            "key": {
+                                                                "type": "VariantName",
+                                                                "name": "two"
+                                                            },
+                                                            "value": {
+                                                                "type": "Pattern",
+                                                                "elements": [
+                                                                    {
+                                                                        "type": "TextElement",
+                                                                        "value": "Value"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "default": true
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Comment",
+            "annotations": [],
+            "content": "ERROR VariantLists cannot appear in SelectExpressions\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "nested-variant-list =\n    { 1 ->\n       *[one] {\n          *[two] Value\n       }\n    }\n"
         }
     ]
 }

--- a/test/fixtures/sparse_entries.ftl
+++ b/test/fixtures/sparse_entries.ftl
@@ -24,7 +24,7 @@ key03 =
 
 key05 =                     Value
 
-key06 = {
+key06 = { 1 ->
 
 
          [one] One

--- a/test/fixtures/sparse_entries.json
+++ b/test/fixtures/sparse_entries.json
@@ -117,7 +117,10 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "SelectExpression",
-                            "selector": null,
+                            "selector": {
+                                "type": "NumberExpression",
+                                "value": "1"
+                            },
                             "variants": [
                                 {
                                     "type": "Variant",

--- a/test/fixtures/variant_lists.ftl
+++ b/test/fixtures/variant_lists.ftl
@@ -1,0 +1,54 @@
+-variant-list-in-term =
+    {
+       *[key] Value
+    }
+
+# ERROR Attributes of Terms must be Patterns.
+-variant-list-in-term-attr = Value
+    .attr =
+        {
+           *[key] Value
+        }
+
+# ERROR Message values must be Patterns.
+variant-list-in-message =
+    {
+       *[key] Value
+    }
+
+# ERROR Attributes of Messages must be Patterns.
+variant-list-in-message-attr = Value
+    .attr =
+        {
+           *[key] Value
+        }
+
+-nested-variant-list-in-term =
+    {
+       *[one] {
+          *[two] Value
+       }
+    }
+
+-nested-select =
+    {
+       *[one] { 2 ->
+          *[two] Value
+       }
+    }
+
+# ERROR VariantLists may not appear in SelectExpressions
+nested-select-then-variant-list =
+    {
+       *[one] { 2 ->
+          *[two] {
+             *[three] Value
+          }
+       }
+    }
+
+# ERROR VariantLists are value types and may not appear in Placeables
+variant-list-in-placeable =
+    A prefix here {
+       *[key] Value
+    } and a postfix here make this a Pattern.

--- a/test/fixtures/variant_lists.json
+++ b/test/fixtures/variant_lists.json
@@ -1,0 +1,225 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Term",
+            "annotations": [],
+            "id": {
+                "type": "Identifier",
+                "name": "-variant-list-in-term"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "VariantName",
+                            "name": "key"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "TextElement",
+                                    "value": "Value"
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "annotations": [],
+            "id": {
+                "type": "Identifier",
+                "name": "-variant-list-in-term-attr"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "annotations": [],
+                "content": "ERROR Attributes of Terms must be Patterns.\n"
+            }
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "    .attr =\n        {\n           *[key] Value\n        }\n"
+        },
+        {
+            "type": "Comment",
+            "annotations": [],
+            "content": "ERROR Message values must be Patterns.\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "variant-list-in-message =\n    {\n       *[key] Value\n    }\n"
+        },
+        {
+            "type": "Message",
+            "annotations": [],
+            "id": {
+                "type": "Identifier",
+                "name": "variant-list-in-message-attr"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "annotations": [],
+                "content": "ERROR Attributes of Messages must be Patterns.\n"
+            }
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "    .attr =\n        {\n           *[key] Value\n        }\n"
+        },
+        {
+            "type": "Term",
+            "annotations": [],
+            "id": {
+                "type": "Identifier",
+                "name": "-nested-variant-list-in-term"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "VariantName",
+                            "name": "one"
+                        },
+                        "value": {
+                            "type": "VariantList",
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "VariantName",
+                                        "name": "two"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Value"
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "annotations": [],
+            "id": {
+                "type": "Identifier",
+                "name": "-nested-select"
+            },
+            "value": {
+                "type": "VariantList",
+                "variants": [
+                    {
+                        "type": "Variant",
+                        "key": {
+                            "type": "VariantName",
+                            "name": "one"
+                        },
+                        "value": {
+                            "type": "Pattern",
+                            "elements": [
+                                {
+                                    "type": "Placeable",
+                                    "expression": {
+                                        "type": "SelectExpression",
+                                        "selector": {
+                                            "type": "NumberExpression",
+                                            "value": "2"
+                                        },
+                                        "variants": [
+                                            {
+                                                "type": "Variant",
+                                                "key": {
+                                                    "type": "VariantName",
+                                                    "name": "two"
+                                                },
+                                                "value": {
+                                                    "type": "Pattern",
+                                                    "elements": [
+                                                        {
+                                                            "type": "TextElement",
+                                                            "value": "Value"
+                                                        }
+                                                    ]
+                                                },
+                                                "default": true
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "default": true
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Comment",
+            "annotations": [],
+            "content": "ERROR VariantLists may not appear in SelectExpressions\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "nested-select-then-variant-list =\n    {\n       *[one] { 2 ->\n          *[two] {\n             *[three] Value\n          }\n       }\n    }\n"
+        },
+        {
+            "type": "Comment",
+            "annotations": [],
+            "content": "ERROR VariantLists are value types and may not appear in Placeables\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "variant-list-in-placeable =\n    A prefix here {\n       *[key] Value\n    } and a postfix here make this a Pattern.\n"
+        }
+    ]
+}


### PR DESCRIPTION
This PR removes selector-less `SelectExpressions` in favor of `VariantLists` which share the same syntax. Values of `Messages` and `Terms` may now be either `Patterns` or `VariantLists`. Values of `Variants` may only be `VariantLists` if they're defined in another `VariantList`.

Fixes #102.