### PR TITLE
Initial syntax hightlighting for vim/neovim

### DIFF
--- a/editors/vim/syntax/fluent.vim
+++ b/editors/vim/syntax/fluent.vim
@@ -1,0 +1,26 @@
+if exists("b:current_syntax")
+    finish
+endif
+
+syntax match fluentComment "\v#.*$"
+syntax match fluentIdentifier "^\v[a-zA-Z-]+" nextgroup=fluentDelimiter
+syntax match fluentDelimiter "\s*=\s*" contained skipnl nextgroup=fluentPattern
+syntax region fluentPattern contained start="" end="\v^(( )@!|( +[\.\[\*\}])@=)" contains=fluentPlaceableExpression
+syntax match fluentAttribute "\v\.[a-zA-Z-]+" nextgroup=fluentDelimiter
+syntax region fluentPlaceableExpression contained matchgroup=fluentPlaceableBraces start=+{+ end=+}+ contains=@fluentExpression
+
+syntax cluster fluentExpression contains=fluentBuiltin,fluentVariantEntry,fluentIdentifierExpression
+
+syntax match fluentBuiltin contained "\v[A-Z]+(\()@="
+syntax match fluentVariantEntry contained "\v\*?\[[a-z]+\]" nextgroup=fluentPattern
+syntax match fluentIdentifierExpression contained "\v[a-zA-Z-]+"
+
+highlight link fluentComment Comment
+highlight link fluentIdentifier Identifier
+highlight link fluentPattern String
+highlight link fluentAttribute Keyword
+highlight link fluentBuiltin Keyword
+highlight link fluentVariantEntry Keyword
+highlight link fluentIdentifierExpression Identifier
+
+let b:current_syntax = "fluent"


### PR DESCRIPTION
While waiting for Firefox to recompile I put together some very basic syntax highlighting for vim. It does decent job when looking at .ftl files in `mozilla-central` at least and maybe be a good foundation.

Not sure if you want to handle those in tree or in gist all around or some separate repo, but I think the easiest location would be in this repo so placing it as a PR.