### PR TITLE
Add spec/valid.md with rules for validating well-formed syntax

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -29,7 +29,8 @@ TextElement                ::= (text_char | text_cont)+
 Placeable                  ::= "{" inline_space? (SelectExpression | InlineExpression) inline_space? "}"
 
 /* Rules for validating expressions in Placeables and as selectors of
- * SelectExpressions are enforced in syntax/abstract.mjs. */
+ * SelectExpressions are documented in spec/valid.md and enforced in
+ * syntax/abstract.mjs. */
 InlineExpression           ::= StringLiteral
                              | NumberLiteral
                              | VariableReference

--- a/spec/valid.md
+++ b/spec/valid.md
@@ -1,0 +1,58 @@
+# Valid Fluent Syntax
+
+Fluent Syntax distinguishes between well-formed and valid resources.
+
+  - Well-formed Fluent resources conform to the Fluent grammar described by the
+    Fluent EBNF (`spec/fluent.ebnf`).
+
+  - Valid Fluent resources are additionally checked for semantic correctness.
+    The validation process may reject syntax which is well-formed.
+
+This document describes the semantic rules which check validity of well-formed
+Fluent resources. The rules are defined using a CSS-like selector syntax.
+
+## Patterns
+
+Well-formed Patterns:
+
+    Message.value > Pattern
+    Term.value > Pattern
+    Attribute.value > Pattern
+    Variant.value > Pattern
+
+## VariantLists
+
+Well-formed VariantLists:
+
+    Message.value > VariantList
+    Term.value > VariantList
+    Attribute.value > VariantList
+    Variant.value > VariantList
+
+Invalid VariantLists:
+
+    Message.value VariantList
+    SelectExpression.variants > Variant.value > VariantList
+
+## Placeables
+
+Well-formed Placeables:
+
+    Placeable.expression > Expression
+
+Invalid Placeables:
+
+    Placeable.expression > AttributeExpression.ref > TermReference
+
+## Select Expressions
+
+Well-formed Select Expressions:
+
+    SelectExpression.selector > Expression:not(SelectExpression)
+
+Invalid Select Expressions:
+
+    SelectExpression.selector > MessageReference
+    SelectExpression.selector > TermReference
+    SelectExpression.selector > VariantExpression
+    SelectExpression.selector > AttributeExpression.ref > MessageReference

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -2,8 +2,7 @@
  * AST Validation
  *
  * The parse result of the grammar.mjs parser is a well-formed AST which is
- * validated according to the rules documented on the wiki:
- * https://github.com/projectfluent/fluent/wiki/Syntax-Semantics
+ * validated according to the rules documented in `spec/valid.md`.
  */
 
 import * as FTL from "./ast.mjs";

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -169,9 +169,10 @@ let Placeable = defer(() =>
     .map(element_at(2))
     .chain(into(FTL.Placeable)));
 
-/* ------------------------------------------------------------------ */
+/* ------------------------------------------------------------------- */
 /* Rules for validating expressions in Placeables and as selectors of
- * SelectExpressions are enforced in syntax/abstract.mjs. */
+ * SelectExpressions are documented in spec/valid.md and enforced in
+ * syntax/abstract.mjs. */
 let InlineExpression = defer(() =>
     either(
         StringLiteral,


### PR DESCRIPTION
Fix #99.