### PR TITLE
unify char and string, just use char as it's the smaller diff, fixes #108

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
         }],
         "quotes": ["error", "double"],
         "semi": ["error", "always"],
+        "space-infix-ops": ["error"],
         "no-tabs": "error",
         "no-undef": "error"
     }

--- a/lib/combinators.mjs
+++ b/lib/combinators.mjs
@@ -9,7 +9,7 @@ export function defer(fn) {
         fn().run(stream));
 }
 
-export function char(str) {
+export function string(str) {
     return new Parser(stream =>
         stream.head(str.length) === str
             ? new Success(str, stream.move(str.length))

--- a/lib/combinators.mjs
+++ b/lib/combinators.mjs
@@ -9,11 +9,11 @@ export function defer(fn) {
         fn().run(stream));
 }
 
-export function char(c) {
+export function char(str) {
     return new Parser(stream =>
-        stream.head() === c
-            ? new Success(c, stream.move(1))
-            : new Failure(`${c} not found`, stream));
+        stream.head(str.length) === str
+            ? new Success(str, stream.move(str.length))
+            : new Failure(`${str} not found`, stream));
 }
 
 export function regex(re) {
@@ -32,10 +32,6 @@ export function regex(re) {
 
 export function charset(range) {
     return regex(new RegExp(`[${range}]`));
-}
-
-export function string(str) {
-    return sequence(...str.split("").map(char)).map(join);
 }
 
 export function eof() {

--- a/lib/stream.mjs
+++ b/lib/stream.mjs
@@ -8,7 +8,7 @@ export default class Stream {
     }
 
     // Get the element at the cursor.
-    head() {
+    head(len=1) {
         if (this.length < 0) {
             return undefined;
         }
@@ -17,7 +17,10 @@ export default class Stream {
             return Symbol.for("eof");
         }
 
-        return this.iterable[this.cursor];
+        if (len === 1) {
+            return this.iterable[this.cursor];
+        }
+        return this.iterable.slice(this.cursor, this.cursor + len);
     }
 
     // Execute a regex on the iterable.

--- a/lib/stream.mjs
+++ b/lib/stream.mjs
@@ -17,9 +17,6 @@ export default class Stream {
             return Symbol.for("eof");
         }
 
-        if (len === 1) {
-            return this.iterable[this.cursor];
-        }
         return this.iterable.slice(this.cursor, this.cursor + len);
     }
 

--- a/lib/stream.mjs
+++ b/lib/stream.mjs
@@ -8,7 +8,7 @@ export default class Stream {
     }
 
     // Get the element at the cursor.
-    head(len=1) {
+    head(len = 1) {
         if (this.length < 0) {
             return undefined;
         }

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -2,7 +2,7 @@ import * as FTL from "./ast.mjs";
 import {list_into, into} from "./abstract.mjs";
 import {
     always, and, char, charset, defer, either, eof, maybe, not,
-    regex, repeat, repeat1, sequence, string
+    regex, repeat, repeat1, sequence
 } from "../lib/combinators.mjs";
 import {
     element_at, flatten, join, keep_abstract, mutate, print
@@ -74,7 +74,7 @@ let Comment = defer(() =>
 let GroupComment = defer(() =>
     repeat1(
         sequence(
-            string("##"),
+            char("##"),
             comment_line.abstract))
     .map(flatten(1))
     .map(keep_abstract)
@@ -84,7 +84,7 @@ let GroupComment = defer(() =>
 let ResourceComment = defer(() =>
     repeat1(
         sequence(
-            string("###"),
+            char("###"),
             comment_line.abstract))
     .map(flatten(1))
     .map(keep_abstract)
@@ -282,7 +282,7 @@ let SelectExpression = defer(() =>
     sequence(
         InlineExpression.abstract,
         maybe(inline_space),
-        string("->"),
+        char("->"),
         variant_list.abstract)
     .map(keep_abstract)
     .chain(list_into(FTL.SelectExpression)));
@@ -462,7 +462,7 @@ let inline_space =
 
 let line_end =
     either(
-        string("\u000D\u000A"),
+        char("\u000D\u000A"),
         char("\u000A"),
         char("\u000D"),
         eof());


### PR DESCRIPTION
This patch adresses my comments that ended up being issue #108.

I did run this patch through bench, didn't matter much.

I started digging into this as I hacked on the backports branch, and it took me hours to figure out why `char("//")` doesn't work. Cause that also just silently failed :-)