### PR TITLE
Don't include the trailing line break in Messages, Terms and Comments

### DIFF
--- a/lib/combinators.mjs
+++ b/lib/combinators.mjs
@@ -91,7 +91,7 @@ export function maybe(parser) {
             .run(stream)
             .fold(
                 (value, tail) => new Success(value, tail),
-                (value, tail) => new Success(undefined, stream)));
+                (value, tail) => new Success(null, stream)));
 }
 
 export function append(p1, p2) {

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -1,14 +1,14 @@
 
 /* An FTL file defines a Resource. */
-Resource            ::= (blank_line | Entry | junk_line)*
-Entry               ::= Message
-                      | Term
+Resource            ::= (Entry | blank_line | junk_line)*
+Entry               ::= (Message line_end)
+                      | (Term line_end)
                       | (ResourceComment | GroupComment | Comment)
-Message             ::= Comment? Identifier inline_space? "=" inline_space? ((Pattern Attribute*) | (Attribute+)) line_end
-Term                ::= Comment? TermIdentifier inline_space? "=" inline_space? Value Attribute* line_end
-Comment             ::= ("#" comment_line)+
-GroupComment        ::= ("##" comment_line)+
-ResourceComment     ::= ("###" comment_line)+
+Message             ::= Comment? Identifier inline_space? "=" inline_space? ((Pattern Attribute*) | (Attribute+))
+Term                ::= Comment? TermIdentifier inline_space? "=" inline_space? Value Attribute*
+Comment             ::= ("#" ("\u0020" /.*/)? line_end)+
+GroupComment        ::= ("##" ("\u0020" /.*/)? line_end)+
+ResourceComment     ::= ("###" ("\u0020" /.*/)? line_end)+
 
 /* Adjacent junk_lines should be joined into FTL.Junk during the AST
    construction. */
@@ -73,8 +73,6 @@ Function            ::= [A-Z] [A-Z_?-]*
 
 /* Tokens */
 identifier          ::= [a-zA-Z] [a-zA-Z0-9_-]*
-comment_line        ::= (line_end)
-                      | ("\u0020" /.*/ line_end)
 word                ::= (regular_char - backslash - "}" - "{" - "]" - "[")+
 
 /* Characters */

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -82,6 +82,25 @@ export function list_into(Type) {
 
 export function into(Type) {
     switch (Type) {
+        case FTL.Comment:
+        case FTL.GroupComment:
+        case FTL.ResourceComment:
+            return content => {
+                if (content.endsWith("\n")) {
+                    if (content.endsWith("\r\n")) {
+                        var offset = -2;
+                    } else {
+                        var offset = -1;
+                    }
+                } else if (content.endsWith("\r")) {
+                    var offset = -1;
+                } else {
+                    // The comment ended with the EOF; don't trim it.
+                    return always(new Type(content));
+                }
+                // Trim the EOL from the end of the comment.
+                return always(new Type(content.slice(0, offset)));
+            };
         case FTL.Placeable:
             return expression => {
                 let invalid_expression_found =

--- a/syntax/ast.mjs
+++ b/syntax/ast.mjs
@@ -18,17 +18,8 @@ export class Resource extends SyntaxNode {
     }
 }
 
-export class Entry extends SyntaxNode {
-    constructor() {
-        super();
-        this.type = "Entry";
-        this.annotations = [];
-    }
-
-    addAnnotation(annot) {
-        this.annotations.push(annot);
-    }
-}
+// An abstract base class for useful elements of Resource.body.
+export class Entry extends SyntaxNode {}
 
 export class Message extends Entry {
     constructor(id, value = null, attributes = [], comment = null) {
@@ -245,11 +236,16 @@ export class Function extends Identifier {
     }
 }
 
-export class Junk extends Entry {
+export class Junk extends SyntaxNode {
     constructor(content) {
         super();
         this.type = "Junk";
+        this.annotations = [];
         this.content = content;
+    }
+
+    addAnnotation(annot) {
+        this.annotations.push(annot);
     }
 }
 

--- a/test/fixtures/call_expressions.json
+++ b/test/fixtures/call_expressions.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "positional-args"
@@ -46,7 +45,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "named-args"
@@ -96,7 +94,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "dense-named-args"
@@ -146,7 +143,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "mixed-args"
@@ -212,8 +208,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "ERROR Positional arg must not follow keyword args\n"
+            "content": "ERROR Positional arg must not follow keyword args"
         },
         {
             "type": "Junk",
@@ -222,8 +217,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "ERROR Named arguments must be unique\n"
+            "content": "ERROR Named arguments must be unique"
         },
         {
             "type": "Junk",
@@ -232,12 +226,10 @@
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "Whitespace around arguments\n"
+            "content": "Whitespace around arguments"
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "sparse-inline-call"
@@ -288,7 +280,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "empty-inline-call"
@@ -315,7 +306,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "multiline-call"
@@ -366,7 +356,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "sparse-multiline-call"
@@ -417,7 +406,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "empty-multiline-call"
@@ -444,8 +432,7 @@
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "Syntax errors for multiline call expressions\n"
+            "content": "Syntax errors for multiline call expressions"
         },
         {
             "type": "Junk",
@@ -489,12 +476,10 @@
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "Optional trailing comma\n"
+            "content": "Optional trailing comma"
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "one-argument"
@@ -526,7 +511,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "many-arguments"
@@ -566,7 +550,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "inline-sparse-args"
@@ -606,7 +589,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "mulitline-args"
@@ -642,7 +624,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "mulitline-sparse-args"
@@ -678,8 +659,7 @@
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "Syntax errors for trailing comma\n"
+            "content": "Syntax errors for trailing comma"
         },
         {
             "type": "Junk",
@@ -688,12 +668,10 @@
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "Whitespace in named arguments\n"
+            "content": "Whitespace in named arguments"
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "sparse-named-arg"
@@ -754,8 +732,7 @@
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "Syntax errors for named arguments\n"
+            "content": "Syntax errors for named arguments"
         },
         {
             "type": "Junk",

--- a/test/fixtures/comments.json
+++ b/test/fixtures/comments.json
@@ -3,12 +3,10 @@
     "body": [
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "Standalone Comment\n"
+            "content": "Standalone Comment"
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "foo"
@@ -25,13 +23,11 @@
             "attributes": [],
             "comment": {
                 "type": "Comment",
-                "annotations": [],
-                "content": "Message Comment\n"
+                "content": "Message Comment"
             }
         },
         {
             "type": "Term",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "-term"
@@ -48,24 +44,20 @@
             "attributes": [],
             "comment": {
                 "type": "Comment",
-                "annotations": [],
-                "content": "Term Comment\nwith a blank last line.\n\n"
+                "content": "Term Comment\nwith a blank last line.\n"
             }
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "Another standalone\n\n     with indent\n"
+            "content": "Another standalone\n\n     with indent"
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "Group Comment\n"
+            "content": "Group Comment"
         },
         {
             "type": "ResourceComment",
-            "annotations": [],
-            "content": "Resource Comment\n"
+            "content": "Resource Comment"
         }
     ]
 }

--- a/test/fixtures/eof_comment.json
+++ b/test/fixtures/eof_comment.json
@@ -3,12 +3,10 @@
     "body": [
         {
             "type": "ResourceComment",
-            "annotations": [],
-            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+            "content": "NOTE: Disable final newline insertion when editing this file."
         },
         {
             "type": "Comment",
-            "annotations": [],
             "content": "No EOL"
         }
     ]

--- a/test/fixtures/eof_id.json
+++ b/test/fixtures/eof_id.json
@@ -3,8 +3,7 @@
     "body": [
         {
             "type": "ResourceComment",
-            "annotations": [],
-            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+            "content": "NOTE: Disable final newline insertion when editing this file."
         },
         {
             "type": "Junk",

--- a/test/fixtures/eof_id_equals.json
+++ b/test/fixtures/eof_id_equals.json
@@ -3,8 +3,7 @@
     "body": [
         {
             "type": "ResourceComment",
-            "annotations": [],
-            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+            "content": "NOTE: Disable final newline insertion when editing this file."
         },
         {
             "type": "Junk",

--- a/test/fixtures/eof_junk.json
+++ b/test/fixtures/eof_junk.json
@@ -3,8 +3,7 @@
     "body": [
         {
             "type": "ResourceComment",
-            "annotations": [],
-            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+            "content": "NOTE: Disable final newline insertion when editing this file."
         },
         {
             "type": "Junk",

--- a/test/fixtures/eof_value.json
+++ b/test/fixtures/eof_value.json
@@ -3,12 +3,10 @@
     "body": [
         {
             "type": "ResourceComment",
-            "annotations": [],
-            "content": "NOTE: Disable final newline insertion when editing this file.\n"
+            "content": "NOTE: Disable final newline insertion when editing this file."
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "no-eol"

--- a/test/fixtures/escaped_characters.json
+++ b/test/fixtures/escaped_characters.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "backslash"
@@ -22,7 +21,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "closing-brace"
@@ -41,7 +39,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "unicode-escape"
@@ -60,7 +57,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "escaped-unicode"
@@ -79,12 +75,10 @@
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "String Expressions\n"
+            "content": "String Expressions"
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "quote-in-string"
@@ -106,7 +100,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "backslash-in-string"

--- a/test/fixtures/leading_dots.json
+++ b/test/fixtures/leading_dots.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key01"
@@ -22,7 +21,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key02"
@@ -41,7 +39,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key03"
@@ -67,7 +64,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key04"
@@ -93,7 +89,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key05"
@@ -123,7 +118,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key06"
@@ -153,7 +147,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key07"
@@ -170,8 +163,7 @@
             "attributes": [],
             "comment": {
                 "type": "Comment",
-                "annotations": [],
-                "content": "MESSAGE (value = \"Value\", attributes = [])\nJUNK (attr .Continued\" must have a value)\n"
+                "content": "MESSAGE (value = \"Value\", attributes = [])\nJUNK (attr .Continued\" must have a value)"
             }
         },
         {
@@ -181,8 +173,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK (attr .Value must have a value)\n"
+            "content": "JUNK (attr .Value must have a value)"
         },
         {
             "type": "Junk",
@@ -191,8 +182,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK (attr .Value must have a value)\n"
+            "content": "JUNK (attr .Value must have a value)"
         },
         {
             "type": "Junk",
@@ -201,7 +191,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key10"
@@ -229,7 +218,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key11"
@@ -255,7 +243,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key12"
@@ -283,7 +270,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key13"
@@ -311,7 +297,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key14"
@@ -346,7 +331,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key15"
@@ -414,8 +398,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK (variant must have a value)\n"
+            "content": "JUNK (variant must have a value)"
         },
         {
             "type": "Junk",
@@ -424,8 +407,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK (unclosed placeable)\n"
+            "content": "JUNK (unclosed placeable)"
         },
         {
             "type": "Junk",

--- a/test/fixtures/literal_expressions.json
+++ b/test/fixtures/literal_expressions.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "string-expression"
@@ -25,7 +24,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "number-expression"
@@ -47,7 +45,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "number-expression"

--- a/test/fixtures/member_expressions.json
+++ b/test/fixtures/member_expressions.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "variant-expression"
@@ -35,7 +34,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "attribute-expression"
@@ -67,8 +65,7 @@
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "Invalid syntax\n"
+            "content": "Invalid syntax"
         },
         {
             "type": "Junk",

--- a/test/fixtures/messages.json
+++ b/test/fixtures/messages.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key01"
@@ -22,7 +21,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key02"
@@ -58,7 +56,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key02"
@@ -110,7 +107,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key03"
@@ -138,7 +134,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key04"
@@ -182,7 +177,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key05"
@@ -208,13 +202,11 @@
             ],
             "comment": {
                 "type": "Comment",
-                "annotations": [],
-                "content": "     <  whitespace  >\n"
+                "content": "     <  whitespace  >"
             }
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key06"
@@ -236,8 +228,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK Missing value\n"
+            "content": "JUNK Missing value"
         },
         {
             "type": "Junk",
@@ -246,8 +237,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK Missing =\n"
+            "content": "JUNK Missing ="
         },
         {
             "type": "Junk",

--- a/test/fixtures/mixed_entries.json
+++ b/test/fixtures/mixed_entries.json
@@ -3,17 +3,14 @@
     "body": [
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "License Comment\n"
+            "content": "License Comment"
         },
         {
             "type": "ResourceComment",
-            "annotations": [],
-            "content": "Resource Comment\n"
+            "content": "Resource Comment"
         },
         {
             "type": "Term",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "-brand-name"
@@ -32,12 +29,10 @@
         },
         {
             "type": "GroupComment",
-            "annotations": [],
-            "content": "Group Comment\n"
+            "content": "Group Comment"
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key01"
@@ -70,7 +65,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key02"
@@ -87,14 +81,12 @@
             "attributes": [],
             "comment": {
                 "type": "Comment",
-                "annotations": [],
-                "content": "Message Comment\n"
+                "content": "Message Comment"
             }
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "Standalone Comment\n"
+            "content": "Standalone Comment"
         },
         {
             "type": "Junk",

--- a/test/fixtures/multiline_values.json
+++ b/test/fixtures/multiline_values.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key01"
@@ -22,7 +21,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key02"
@@ -41,7 +39,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key03"
@@ -69,7 +66,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key04"
@@ -97,7 +93,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key05"
@@ -116,7 +111,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key06"
@@ -171,7 +165,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key07"
@@ -204,7 +197,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key08"

--- a/test/fixtures/placeables.json
+++ b/test/fixtures/placeables.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "nested-placeable"
@@ -31,7 +30,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "padded-placeable"
@@ -53,7 +51,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "sparse-placeable"

--- a/test/fixtures/reference_expressions.json
+++ b/test/fixtures/reference_expressions.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "message-reference"
@@ -28,7 +27,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "term-reference"
@@ -53,7 +51,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "variable-reference"
@@ -78,7 +75,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "not-call-expression"

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "new-messages"
@@ -76,7 +75,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "valid-selector"
@@ -130,8 +128,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "ERROR\n"
+            "content": "ERROR"
         },
         {
             "type": "Junk",
@@ -140,7 +137,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "empty-variant"
@@ -187,7 +183,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "nested-select"
@@ -256,8 +251,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "ERROR VariantLists cannot appear in SelectExpressions\n"
+            "content": "ERROR VariantLists cannot appear in SelectExpressions"
         },
         {
             "type": "Junk",

--- a/test/fixtures/sparse_entries.json
+++ b/test/fixtures/sparse_entries.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key01"
@@ -22,7 +21,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key02"
@@ -50,7 +48,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key03"
@@ -86,7 +83,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key05"
@@ -105,7 +101,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "key06"

--- a/test/fixtures/terms.json
+++ b/test/fixtures/terms.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Term",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "-term01"
@@ -39,7 +38,6 @@
         },
         {
             "type": "Term",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "-term02"
@@ -61,8 +59,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK Missing value\n"
+            "content": "JUNK Missing value"
         },
         {
             "type": "Junk",
@@ -71,8 +68,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK Missing value\n       <  whitespace  >\n"
+            "content": "JUNK Missing value\n       <  whitespace  >"
         },
         {
             "type": "Junk",
@@ -81,8 +77,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK Missing value\n"
+            "content": "JUNK Missing value"
         },
         {
             "type": "Junk",
@@ -91,8 +86,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK Missing value\n       <  whitespace  >\n"
+            "content": "JUNK Missing value\n       <  whitespace  >"
         },
         {
             "type": "Junk",
@@ -101,8 +95,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "JUNK Missing =\n"
+            "content": "JUNK Missing ="
         },
         {
             "type": "Junk",

--- a/test/fixtures/variant_lists.json
+++ b/test/fixtures/variant_lists.json
@@ -3,7 +3,6 @@
     "body": [
         {
             "type": "Term",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "-variant-list-in-term"
@@ -35,7 +34,6 @@
         },
         {
             "type": "Term",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "-variant-list-in-term-attr"
@@ -52,8 +50,7 @@
             "attributes": [],
             "comment": {
                 "type": "Comment",
-                "annotations": [],
-                "content": "ERROR Attributes of Terms must be Patterns.\n"
+                "content": "ERROR Attributes of Terms must be Patterns."
             }
         },
         {
@@ -63,8 +60,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "ERROR Message values must be Patterns.\n"
+            "content": "ERROR Message values must be Patterns."
         },
         {
             "type": "Junk",
@@ -73,7 +69,6 @@
         },
         {
             "type": "Message",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "variant-list-in-message-attr"
@@ -90,8 +85,7 @@
             "attributes": [],
             "comment": {
                 "type": "Comment",
-                "annotations": [],
-                "content": "ERROR Attributes of Messages must be Patterns.\n"
+                "content": "ERROR Attributes of Messages must be Patterns."
             }
         },
         {
@@ -101,7 +95,6 @@
         },
         {
             "type": "Term",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "-nested-variant-list-in-term"
@@ -146,7 +139,6 @@
         },
         {
             "type": "Term",
-            "annotations": [],
             "id": {
                 "type": "Identifier",
                 "name": "-nested-select"
@@ -203,8 +195,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "ERROR VariantLists may not appear in SelectExpressions\n"
+            "content": "ERROR VariantLists may not appear in SelectExpressions"
         },
         {
             "type": "Junk",
@@ -213,8 +204,7 @@
         },
         {
             "type": "Comment",
-            "annotations": [],
-            "content": "ERROR VariantLists are value types and may not appear in Placeables\n"
+            "content": "ERROR VariantLists are value types and may not appear in Placeables"
         },
         {
             "type": "Junk",


### PR DESCRIPTION
Revert earlier changes which added the trailing newline to the
definition of the Message, Term and Comment, as well as to the content
of Comments. The trailing line break should not be part of the
production, span nor the content.

Make Junk subclass SyntaxNode directly, rather than Entry. Entry is now
an abstract class for useful AST nodes carrying content: Messages, Terms
and Comments.

Remove the annotations field from Entry togather with the add_annotation
method and move it directly onto Junk.