### PR TITLE
Parse Patterns and Comments line-by-line

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -1,11 +1,11 @@
 
 /* An FTL file defines a Resource. */
 Resource            ::= (Entry | blank_block | junk_line)*
-Entry               ::= (Message line_end)
-                      | (Term line_end)
+Entry               ::= Message
+                      | Term
                       | (ResourceComment | GroupComment | Comment)
-Message             ::= Comment? Identifier blank_inline? "=" blank_inline? ((Pattern Attribute*) | (Attribute+))
-Term                ::= Comment? TermIdentifier blank_inline? "=" blank_inline? Value Attribute*
+Message             ::= Comment? Identifier blank_inline? "=" ((Pattern Attribute*) | (Attribute+))
+Term                ::= Comment? TermIdentifier blank_inline? "=" Value Attribute*
 Comment             ::= ("#" ("\u0020" /.*/)? line_end)+
 GroupComment        ::= ("##" ("\u0020" /.*/)? line_end)+
 ResourceComment     ::= ("###" ("\u0020" /.*/)? line_end)+
@@ -15,17 +15,23 @@ ResourceComment     ::= ("###" ("\u0020" /.*/)? line_end)+
 junk_line           ::= /.*/ line_end
 
 /* Attributes of Messages and Terms. */
-Attribute           ::= line_end blank? "." Identifier blank_inline? "=" blank_inline? Pattern
+Attribute           ::= blank? "." Identifier blank_inline? "=" Pattern
 
 /* Value types: Pattern and VariantList. */
-Value               ::= Pattern
-                      | VariantList
-Pattern             ::= PatternElement+
+Value               ::= VariantList
+                      | Pattern
 VariantList         ::= blank? "{" variant_list blank? "}"
+Pattern             ::= (PatternInline PatternBlock)
+                      | PatternInline
+                      | PatternBlock
+PatternInline       ::= blank_inline? PatternElement+ line_end
+PatternBlock        ::= blank_block* pattern_line (pattern_line | blank_block)*
+pattern_line        ::= PatternStartElement PatternElement* line_end
 PatternElement      ::= TextElement
                       | Placeable
-                      | (blank_block blank_inline? Placeable)
-TextElement         ::= (text_char | text_cont)+
+PatternStartElement ::= (blank_inline text_start)
+                      | (blank_inline? Placeable)
+TextElement         ::= text_char+
 Placeable           ::= "{" blank? (SelectExpression | InlineExpression) blank? "}"
 
 /* Rules for validating expressions in Placeables and as selectors of
@@ -58,10 +64,10 @@ AttributeExpression ::= (MessageReference | TermReference) "." Identifier
 VariantExpression   ::= TermReference VariantKey
 
 /* Block Expressions */
-SelectExpression    ::= InlineExpression blank? "->" blank_inline? variant_list
-variant_list        ::= Variant* DefaultVariant Variant* line_end
-Variant             ::= line_end blank? VariantKey blank_inline? Value
-DefaultVariant      ::= line_end blank? "*" VariantKey blank_inline? Value
+SelectExpression    ::= InlineExpression blank? "->" variant_list
+variant_list        ::= blank_block Variant* DefaultVariant Variant*
+Variant             ::= blank? VariantKey Value
+DefaultVariant      ::= blank? "*" VariantKey Value
 VariantKey          ::= "[" blank? (NumberLiteral | VariantName) blank? "]"
 VariantName         ::= word (blank word)*
 
@@ -89,7 +95,7 @@ text_char           ::= blank_inline
                       | (backslash backslash)
                       | (backslash "{")
                       | (regular_char - "{" - backslash)
-text_cont           ::= blank_block blank_inline (text_char - "}" - "[" - "*" - ".")
+text_start          ::= text_char - "}" - "[" - "*" - "."
 quoted_text_char    ::= (text_char - quote)
                       | (backslash quote)
 digit               ::= [0-9]

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -3,12 +3,10 @@
 Resource            ::= (Entry | blank_block | junk_line)*
 Entry               ::= Message
                       | Term
-                      | (ResourceComment | GroupComment | Comment)
-Message             ::= Comment? Identifier blank_inline? "=" ((Pattern Attribute*) | (Attribute+))
-Term                ::= Comment? TermIdentifier blank_inline? "=" Value Attribute*
-Comment             ::= ("#" ("\u0020" /.*/)? line_end)+
-GroupComment        ::= ("##" ("\u0020" /.*/)? line_end)+
-ResourceComment     ::= ("###" ("\u0020" /.*/)? line_end)+
+                      | CommentLine
+Message             ::= Identifier blank_inline? "=" ((Pattern Attribute*) | (Attribute+))
+Term                ::= TermIdentifier blank_inline? "=" Value Attribute*
+CommentLine         ::= ("###" | "##" | "#") ("\u0020" /.*/)? line_end
 
 /* Adjacent junk_lines should be joined into FTL.Junk during the AST
    construction. */

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -10,6 +10,19 @@ import {always, never} from "../lib/combinators.mjs";
 
 export function list_into(Type) {
     switch (Type) {
+        case FTL.BaseComment:
+            return ([sigil, content = ""]) => {
+                switch (sigil) {
+                    case "#":
+                        return always(new FTL.Comment(content));
+                    case "##":
+                        return always(new FTL.GroupComment(content));
+                    case "###":
+                        return always(new FTL.ResourceComment(content));
+                    default:
+                        return never(`Unknown comment sigil: ${sigil}`);
+                }
+            };
         case FTL.CallExpression:
             return ([callee, args]) => {
                 let positional_args = [];
@@ -32,9 +45,6 @@ export function list_into(Type) {
                 let named_args = Array.from(named_map.values());
                 return always(new Type(callee, positional_args, named_args));
             };
-        case FTL.Message:
-            return ([comment, ...args]) =>
-                always(new Type(...args, comment));
         case FTL.Pattern:
             return elements =>
                 always(new FTL.Pattern(
@@ -46,7 +56,12 @@ export function list_into(Type) {
             return entries =>
                 always(new FTL.Resource(
                     entries
-                        .reduce(join_adjacent(FTL.Junk), [])
+                        .reduce(join_adjacent(
+                            FTL.Junk,
+                            FTL.Comment,
+                            FTL.GroupComment,
+                            FTL.ResourceComment), [])
+                        .reduce(attach_comments, [])
                         .filter(remove_blank_lines)));
         case FTL.SelectExpression:
             return ([selector, variants]) => {
@@ -68,9 +83,6 @@ export function list_into(Type) {
                 }
                 return always(new Type(selector, variants));
             };
-        case FTL.Term:
-            return ([comment, ...args]) =>
-                always(new Type(...args, comment));
         case FTL.VariantList:
             return ([variants]) =>
                 always(new Type(variants));
@@ -82,21 +94,6 @@ export function list_into(Type) {
 
 export function into(Type) {
     switch (Type) {
-        case FTL.Comment:
-        case FTL.GroupComment:
-        case FTL.ResourceComment:
-            return content => {
-                if (!content.endsWith("\n")) {
-                    // The comment ended with the EOF; don't trim it.
-                    return always(new Type(content));
-                }
-                if (content.endsWith("\r\n")) {
-                    // Trim the CRLF from the end of the comment.
-                    return always(new Type(content.slice(0, -2)));
-                }
-                // Trim the LF from the end of the comment.
-                return always(new Type(content.slice(0, -1)));
-            };
         case FTL.Placeable:
             return expression => {
                 let invalid_expression_found =
@@ -121,15 +118,16 @@ export function into(Type) {
     }
 }
 
-function join_adjacent(Type) {
+function join_adjacent(...types) {
     return function(acc, cur) {
         let prev = acc[acc.length - 1];
-        if (prev instanceof Type && cur instanceof Type) {
-            join_of_type(Type, prev, cur);
-            return acc;
-        } else {
-            return acc.concat(cur);
+        for (let Type of types) {
+            if (prev instanceof Type && cur instanceof Type) {
+                join_of_type(Type, prev, cur);
+                return acc;
+            }
         }
+        return acc.concat(cur);
     };
 }
 
@@ -139,9 +137,27 @@ function join_of_type(Type, ...elements) {
         case FTL.TextElement:
             return elements.reduce((a, b) =>
                 (a.value += b.value, a));
+        case FTL.Comment:
+        case FTL.GroupComment:
+        case FTL.ResourceComment:
+            return elements.reduce((a, b) =>
+                (a.content += `\n${b.content}`, a));
         case FTL.Junk:
             return elements.reduce((a, b) =>
                 (a.content += b.content, a));
+    }
+}
+
+function attach_comments(acc, cur) {
+    let prev = acc[acc.length - 1];
+    if (prev instanceof FTL.Comment
+        && (cur instanceof FTL.Message
+            || cur instanceof FTL.Term)) {
+        cur.comment = prev;
+        acc[acc.length - 1] = cur;
+        return acc;
+    } else {
+        return acc.concat(cur);
     }
 }
 

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -108,6 +108,13 @@ export function into(Type) {
                 }
                 return always(new Type(expression));
             };
+        case FTL.TextElement:
+            return value => {
+                if (value === Symbol.for("eof")) {
+                    return always(new Type(""));
+                }
+                return always(new Type(value));
+            };
         default:
             return (...args) =>
                 always(new Type(...args));
@@ -151,6 +158,7 @@ function trim_text_at_extremes(element, index, array) {
 }
 
 function remove_empty_text(element) {
+    // Keep Placeables and non-empty TextElements.
     return !(element instanceof FTL.TextElement)
         || element.value !== "";
 }

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -24,14 +24,10 @@ let Entry = defer(() =>
     either(
         Message,
         Term,
-        either(
-            ResourceComment,
-            GroupComment,
-            Comment)));
+        CommentLine));
 
 let Message = defer(() =>
     sequence(
-        maybe(Comment).abstract,
         Identifier.abstract,
         maybe(blank_inline),
         string("="),
@@ -48,7 +44,6 @@ let Message = defer(() =>
 
 let Term = defer(() =>
     sequence(
-        maybe(Comment).abstract,
         TermIdentifier.abstract,
         maybe(blank_inline),
         string("="),
@@ -57,47 +52,20 @@ let Term = defer(() =>
     .map(keep_abstract)
     .chain(list_into(FTL.Term)));
 
-let Comment = defer(() =>
-    repeat1(
-        sequence(
-            string("#"),
-            maybe(
-                sequence(
-                    string(" "),
-                    regex(/.*/).abstract)),
-            line_end.abstract))
-    .map(flatten(2))
-    .map(keep_abstract)
-    .map(join)
-    .chain(into(FTL.Comment)));
-
-let GroupComment = defer(() =>
-    repeat1(
-        sequence(
-            string("##"),
-            maybe(
-                sequence(
-                    string(" "),
-                    regex(/.*/).abstract)),
-            line_end.abstract))
-    .map(flatten(2))
-    .map(keep_abstract)
-    .map(join)
-    .chain(into(FTL.GroupComment)));
-
-let ResourceComment = defer(() =>
-    repeat1(
-        sequence(
+let CommentLine = defer(() =>
+    sequence(
+        either(
             string("###"),
-            maybe(
-                sequence(
-                    string(" "),
-                    regex(/.*/).abstract)),
-            line_end.abstract))
-    .map(flatten(2))
+            string("##"),
+            string("#")).abstract,
+        maybe(
+            sequence(
+                string(" "),
+                regex(/.*/).abstract)),
+        line_end)
+    .map(flatten(1))
     .map(keep_abstract)
-    .map(join)
-    .chain(into(FTL.ResourceComment)));
+    .chain(list_into(FTL.BaseComment)));
 
 /* ----------------------------------------------------------------- */
 /* Adjacent junk_lines should be joined into FTL.Junk during the AST


### PR DESCRIPTION
Based on #159, this is a refactor of the grammar to a more line-by-line-based approach. This is a good refactor: it greatly simplifies the EBNF and moves much of logic related to creating the AST into `abstract.mjs`. This means that the EBNF can be used more effectively now for its primary purpose: validating whether something is correct Fluent or not.