### PR TITLE
Remove support for CR

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -3,8 +3,7 @@
 
 ## Unreleased
 
-  - …
-
+  - Remove support for CR as a line ending. (#154)
 
 ## 0.6.0 (July 24, 2018)
 

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -98,7 +98,6 @@ digit               ::= [0-9]
 inline_space        ::= ("\u0020" | "\u0009")+
 line_end            ::= "\u000D\u000A"
                       | "\u000A"
-                      | "\u000D"
                       | EOF
 blank_line          ::= inline_space? line_end
 break_indent        ::= line_end blank_line* inline_space

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -86,20 +86,16 @@ export function into(Type) {
         case FTL.GroupComment:
         case FTL.ResourceComment:
             return content => {
-                if (content.endsWith("\n")) {
-                    if (content.endsWith("\r\n")) {
-                        var offset = -2;
-                    } else {
-                        var offset = -1;
-                    }
-                } else if (content.endsWith("\r")) {
-                    var offset = -1;
-                } else {
+                if (!content.endsWith("\n")) {
                     // The comment ended with the EOF; don't trim it.
                     return always(new Type(content));
                 }
-                // Trim the EOL from the end of the comment.
-                return always(new Type(content.slice(0, offset)));
+                if (content.endsWith("\r\n")) {
+                    // Trim the CRLF from the end of the comment.
+                    return always(new Type(content.slice(0, -2)));
+                }
+                // Trim the LF from the end of the comment.
+                return always(new Type(content.slice(0, -1)));
             };
         case FTL.Placeable:
             return expression => {

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -467,7 +467,6 @@ let line_end =
     either(
         string("\u000D\u000A"),
         string("\u000A"),
-        string("\u000D"),
         eof());
 
 let blank_line =


### PR DESCRIPTION
Fix #154.

The second commit normalizes the parsing of all supported line endings to `LF`. We already use `LF` to represent blank lines in multiline patterns. Normalizing line endings in the parsed results removes surprises and ensures consistency across platforms. Serializers can implement an option to serialize using `CRLF` if so desired.

In essence, this is similar to git's [`core.autocrlf = input`](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_code_core_autocrlf_code) option.

