### PR TITLE
Add test for white-space-only lines in values

### DIFF
--- a/test/fixtures/whitespace_in_value.ftl
+++ b/test/fixtures/whitespace_in_value.ftl
@@ -2,6 +2,9 @@
 key =
   first line
 
+
   
+  
+
 
   last line

--- a/test/fixtures/whitespace_in_value.ftl
+++ b/test/fixtures/whitespace_in_value.ftl
@@ -1,4 +1,4 @@
-# Caution, lines 4 and 6 contain white-space-only lines
+# Caution, lines 6 and 7 contain white-space-only lines
 key =
   first line
 

--- a/test/fixtures/whitespace_in_value.ftl
+++ b/test/fixtures/whitespace_in_value.ftl
@@ -1,0 +1,7 @@
+# Caution, lines 4 and 6 contain white-space-only lines
+key =
+  first line
+
+  
+
+  last line

--- a/test/fixtures/whitespace_in_value.json
+++ b/test/fixtures/whitespace_in_value.json
@@ -12,7 +12,7 @@
                 "elements": [
                     {
                         "type": "TextElement",
-                        "value": "first line\n\n\n\nlast line"
+                        "value": "first line\n\n\n\n\n\n\nlast line"
                     }
                 ]
             },

--- a/test/fixtures/whitespace_in_value.json
+++ b/test/fixtures/whitespace_in_value.json
@@ -1,0 +1,26 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "first line\n\n\n\nlast line"
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": {
+                "type": "Comment",
+                "content": "Caution, lines 4 and 6 contain white-space-only lines"
+            }
+        }
+    ]
+}

--- a/test/fixtures/whitespace_in_value.json
+++ b/test/fixtures/whitespace_in_value.json
@@ -19,7 +19,7 @@
             "attributes": [],
             "comment": {
                 "type": "Comment",
-                "content": "Caution, lines 4 and 6 contain white-space-only lines"
+                "content": "Caution, lines 6 and 7 contain white-space-only lines"
             }
         }
     ]


### PR DESCRIPTION
Add a test to codify how we're handling pattern lines with
just indention and completely empty lines.

I.e., both generate an empty line in the message value.

I don't think we have such a test yet, and with all the refactors, I think it'd be good to have. In particular when writing actual implementations based on the reference fixtures.