### PR TITLE
(WIP) Parse TextElement line by line

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -29,14 +29,15 @@ Value               ::= Pattern
                       | VariantList
 Pattern             ::= PatternElement+
 VariantList         ::= blank? "{" variant_list blank? "}"
+
+/* TextElement and Placeable can occur inline or as block.
+ * Text needs to be indented and start with a non-special character.
+ * Placeables can start at the beginning of the line or be indented.
+ * Adjacent TextElements are joined in AST creation. */
 PatternElement      ::= inline_text
                       | block_text
                       | inline_placeable
                       | block_placeable
-
-/* TextElement and Placeable can occur inline or as block.
- * Text needs to be indented and start with a non-special character.
- * Placeables can start at the beginning of the line or be indented. */
 inline_text         ::= text_char+
 block_text          ::= blank_block blank_inline indented_char inline_text?
 inline_placeable    ::= "{" blank? (SelectExpression | InlineExpression) blank? "}"

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -29,18 +29,18 @@ Value               ::= Pattern
                       | VariantList
 Pattern             ::= PatternElement+
 VariantList         ::= blank? "{" variant_list blank? "}"
-PatternElement      ::= TextElement
+PatternElement      ::= inline_text
                       | block_text
-                      | Placeable
+                      | inline_placeable
                       | block_placeable
 
-/* TextElement and Placeable can occur inline or as block.           *
- * Text needs to be indented and start with a non-special character. *
+/* TextElement and Placeable can occur inline or as block.
+ * Text needs to be indented and start with a non-special character.
  * Placeables can start at the beginning of the line or be indented. */
-TextElement         ::= text_char+
-block_text          ::= blank_block blank_inline indented_char text_char*
-Placeable           ::= "{" blank? (SelectExpression | InlineExpression) blank? "}"
-block_placeable     ::= blank_block blank_inline? Placeable
+inline_text         ::= text_char+
+block_text          ::= blank_block blank_inline indented_char inline_text?
+inline_placeable    ::= "{" blank? (SelectExpression | InlineExpression) blank? "}"
+block_placeable     ::= blank_block blank_inline? inline_placeable
 
 /* Rules for validating expressions in Placeables and as selectors of
  * SelectExpressions are documented in spec/valid.md and enforced in
@@ -53,7 +53,7 @@ InlineExpression    ::= StringLiteral
                       | VariantExpression
                       | MessageReference
                       | TermReference
-                      | Placeable
+                      | inline_placeable
 
 /* Literals */
 StringLiteral       ::= quote quoted_text_char* quote

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -32,7 +32,8 @@ VariantList         ::= blank? "{" variant_list blank? "}"
 PatternElement      ::= TextElement
                       | Placeable
                       | (blank_block blank_inline? Placeable)
-TextElement         ::= (text_char | text_cont)+
+TextElement         ::= text_char+
+                      | text_cont
 Placeable           ::= "{" blank? (SelectExpression | InlineExpression) blank? "}"
 
 /* Rules for validating expressions in Placeables and as selectors of
@@ -97,7 +98,7 @@ text_char           ::= blank_inline
                       | (backslash backslash)
                       | (backslash "{")
                       | (regular_char - "{" - backslash)
-text_cont           ::= blank_block blank_inline (text_char - "}" - "[" - "*" - ".")
+text_cont           ::= blank_block blank_inline (text_char - "}" - "[" - "*" - ".") text_char*
 quoted_text_char    ::= (text_char - quote)
                       | (backslash quote)
 digit               ::= [0-9]

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -30,11 +30,17 @@ Value               ::= Pattern
 Pattern             ::= PatternElement+
 VariantList         ::= blank? "{" variant_list blank? "}"
 PatternElement      ::= TextElement
+                      | block_text
                       | Placeable
-                      | (blank_block blank_inline? Placeable)
+                      | block_placeable
+
+/* TextElement and Placeable can occur inline or as block.           *
+ * Text needs to be indented and start with a non-special character. *
+ * Placeables can start at the beginning of the line or be indented. */
 TextElement         ::= text_char+
-                      | text_cont
+block_text          ::= blank_block blank_inline indented_char text_char*
 Placeable           ::= "{" blank? (SelectExpression | InlineExpression) blank? "}"
+block_placeable     ::= blank_block blank_inline? Placeable
 
 /* Rules for validating expressions in Placeables and as selectors of
  * SelectExpressions are documented in spec/valid.md and enforced in
@@ -98,7 +104,7 @@ text_char           ::= blank_inline
                       | (backslash backslash)
                       | (backslash "{")
                       | (regular_char - "{" - backslash)
-text_cont           ::= blank_block blank_inline (text_char - "}" - "[" - "*" - ".") text_char*
+indented_char       ::= text_char - "}" - "[" - "*" - "."
 quoted_text_char    ::= (text_char - quote)
                       | (backslash quote)
 digit               ::= [0-9]

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -148,17 +148,17 @@ let PatternElement = defer(() =>
 let inline_text = defer(() =>
     repeat1(text_char)
     .map(join)
-    .chain(into(FTL.TextElement))
-    .map(te => [te]));
+    .chain(into(FTL.TextElement)));
 
 let block_text = defer(() =>
     sequence(
         blank_block.chain(into(FTL.TextElement)).abstract,
         blank_inline,
         indented_char.chain(into(FTL.TextElement)).abstract,
-        maybe(inline_text.map(element_at(0)).abstract)
+        maybe(inline_text).abstract
     )
-    .map(keep_abstract));
+    .map(keep_abstract)
+    .map(flatten(1)));
 
 let inline_placeable = defer(() =>
     sequence(

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -143,12 +143,13 @@ let PatternElement = defer(() =>
         .map(keep_abstract)));
 
 let TextElement = defer(() =>
-    repeat1(
-        either(
-            text_char,
-            text_cont))
-    .map(join)
-    .chain(into(FTL.TextElement)));
+    either(
+        repeat1(text_char)
+        .map(join)
+        .chain(into(FTL.TextElement))
+        ,
+        text_cont
+    ));
 
 let Placeable = defer(() =>
     sequence(
@@ -426,9 +427,12 @@ let text_cont = defer(() =>
             not(string("*")),
             not(string("[")),
             not(string("}")),
-            text_char).abstract)
+            text_char).abstract,
+        repeat(text_char).abstract)
     .map(keep_abstract)
-    .map(join));
+    .map(flatten(1))
+    .map(join)
+    .chain(into(FTL.TextElement)));
 
 let quoted_text_char =
     either(

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -131,17 +131,18 @@ let VariantList = defer(() =>
     .map(keep_abstract)
     .chain(list_into(FTL.VariantList)));
 
+/* ----------------------------------------------------------------- */
+/* TextElement and Placeable can occur inline or as block.
+ * Text needs to be indented and start with a non-special character.
+ * Placeables can start at the beginning of the line or be indented.
+ * Adjacent TextElements are joined in AST creation. */
+
 let PatternElement = defer(() =>
     either(
         inline_text,
         block_text,
         inline_placeable,
         block_placeable));
-
-/* ----------------------------------------------------------------- */
-/* TextElement and Placeable can occur inline or as block.
- * Text needs to be indented and start with a non-special character.
- * Placeables can start at the beginning of the line or be indented. */
 
 // all of [inline|block]_[text|placeable] return arrays
 let inline_text = defer(() =>
@@ -174,7 +175,6 @@ let inline_placeable = defer(() =>
 
 let block_placeable = defer(() =>
     sequence(
-        // Joined with preceding TextElements during AST construction.
         blank_block.chain(into(FTL.TextElement)).abstract,
         maybe(blank_inline),
         inline_placeable.abstract)

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -117,7 +117,7 @@ let Value = defer(() =>
 let Pattern = defer(() =>
     repeat1(
         PatternElement)
-    // Flatten indented Placeables.
+    // Flatten block_text and block_placeable which return lists.
     .map(flatten(1))
     .chain(list_into(FTL.Pattern)));
 
@@ -144,7 +144,6 @@ let PatternElement = defer(() =>
         inline_placeable,
         block_placeable));
 
-// all of [inline|block]_[text|placeable] return arrays
 let inline_text = defer(() =>
     repeat1(text_char)
     .map(join)

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -133,32 +133,32 @@ let VariantList = defer(() =>
 
 let PatternElement = defer(() =>
     either(
-        TextElement,
+        inline_text
+        .chain(into(FTL.TextElement)),
         block_text,
-        Placeable,
+        inline_placeable,
         block_placeable));
 
 /* ----------------------------------------------------------------- */
-/* TextElement and Placeable can occur inline or as block.           *
- * Text needs to be indented and start with a non-special character. *
+/* TextElement and Placeable can occur inline or as block.
+ * Text needs to be indented and start with a non-special character.
  * Placeables can start at the beginning of the line or be indented. */
-let TextElement = defer(() =>
+let inline_text = defer(() =>
     repeat1(text_char)
-    .map(join)
-    .chain(into(FTL.TextElement)));
+    .map(join));
 
 let block_text = defer(() =>
     sequence(
         blank_block.abstract,
         blank_inline,
         indented_char.abstract,
-        repeat(text_char).abstract)
+        maybe(inline_text).abstract)
     .map(keep_abstract)
     .map(flatten(1))
     .map(join)
 .chain(into(FTL.TextElement)));
 
-let Placeable = defer(() =>
+let inline_placeable = defer(() =>
     sequence(
         string("{"),
         maybe(blank),
@@ -176,8 +176,8 @@ let block_placeable = defer(() =>
         // Joined with preceding TextElements during AST construction.
         blank_block.chain(into(FTL.TextElement)).abstract,
         maybe(blank_inline),
-        Placeable.abstract)
-        .map(keep_abstract));
+        inline_placeable.abstract)
+    .map(keep_abstract));
 
 /* ------------------------------------------------------------------- */
 /* Rules for validating expressions in Placeables and as selectors of
@@ -193,7 +193,7 @@ let InlineExpression = defer(() =>
         VariantExpression,
         MessageReference,
         TermReference,
-        Placeable));
+        inline_placeable));
 
 /* -------- */
 /* Literals */

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -155,10 +155,9 @@ let block_text = defer(() =>
         blank_block.chain(into(FTL.TextElement)).abstract,
         blank_inline,
         indented_char.chain(into(FTL.TextElement)).abstract,
-        maybe(inline_text).abstract
+        maybe(inline_text.abstract)
     )
-    .map(keep_abstract)
-    .map(flatten(1)));
+    .map(keep_abstract));
 
 let inline_placeable = defer(() =>
     sequence(


### PR DESCRIPTION
In order to be able to preserve the indent of multiline text
values for AST generation, we would need to parse TextElements
line by line.

Throwing this in the pool with #168 and #169