### PR TITLE
Don't normalize CRLF to LF in Junk

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 test/fixtures/crlf.ftl eol=crlf
+test/fixtures/cr.ftl eol=cr

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -19,7 +19,7 @@ Term                ::= "-" Identifier blank_inline? "=" blank_inline? Value Att
 CommentLine         ::= ("###" | "##" | "#") ("\u0020" /.*/)? line_end
 
 /* Adjacent junk_lines are joined into FTL.Junk during the AST construction. */
-junk_line           ::= /.*/ line_end
+junk_line           ::= /[^\n]*/ ("\u000A" | EOF)
 
 /* Attributes of Messages and Terms. */
 Attribute           ::= line_end blank? "." Identifier blank_inline? "=" blank_inline? Pattern

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -86,12 +86,14 @@ let CommentLine = defer(() =>
 
 /* ------------------------------------------------------------------------- */
 /* Adjacent junk_lines are joined into FTL.Junk during the AST construction. */
-let junk_line = defer(() =>
+let junk_line =
     sequence(
-        regex(/.*/),
-        line_end)
+        regex(/[^\n]*/),
+        either(
+            string("\u000A"),
+            eof()))
     .map(join)
-    .chain(into(FTL.Junk)));
+    .chain(into(FTL.Junk));
 
 /* --------------------------------- */
 /* Attributes of Messages and Terms. */

--- a/test/fixtures/cr.ftl
+++ b/test/fixtures/cr.ftl
@@ -1,0 +1,1 @@
+### This entire file uses CR as EOL.err01 = Value 01err02 = Value 02err03 =    Value 03    Continued    .title = Titleerr04 = { "strerr05 = { $sel -> }

--- a/test/fixtures/cr.json
+++ b/test/fixtures/cr.json
@@ -1,0 +1,10 @@
+{
+    "type": "Resource",
+    "body": [
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "### This entire file uses CR as EOL.\r\rerr01 = Value 01\rerr02 = Value 02\r\rerr03 =\r\r    Value 03\r    Continued\r\r    .title = Title\r\rerr04 = { \"str\r\rerr05 = { $sel -> }\r"
+        }
+    ]
+}

--- a/test/fixtures/crlf.ftl
+++ b/test/fixtures/crlf.ftl
@@ -1,7 +1,14 @@
+
 key01 = Value 01
 key02 =
+
     Value 02
     Continued
 
-# ERROR (Missing value or attributes)
-key03
+    .title = Title
+
+# ERROR Unclosed StringLiteral
+err03 = { "str
+
+# ERROR Missing newline after ->.
+err04 = { $sel -> }

--- a/test/fixtures/crlf.json
+++ b/test/fixtures/crlf.json
@@ -34,17 +34,43 @@
                     }
                 ]
             },
-            "attributes": [],
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "title"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Title"
+                            }
+                        ]
+                    }
+                }
+            ],
             "comment": null
         },
         {
             "type": "Comment",
-            "content": "ERROR (Missing value or attributes)"
+            "content": "ERROR Unclosed StringLiteral"
         },
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key03\n"
+            "content": "err03 = { \"str\r\n"
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR Missing newline after ->."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "err04 = { $sel -> }\r\n"
         }
     ]
 }


### PR DESCRIPTION
Fix #184.

This doesn't change the parsing story for unsupported line endings (`\r`, `\u2028`, `\u2029`). Right now, that story is largely undefined.

