### PR TITLE
Store unescaped content in StringLiteral.value and raw content in StringLiteral.raw

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -86,6 +86,14 @@
     present in `TextElements`. `{"}"}` can be used to insert a literal
     closing brace.
 
+  - Store both the raw and the unescaped value in `StringLiteral`. (#203)
+
+    `StringLiteral.value` has been change to store the unescaped ("cooked")
+    value of the string literal: all known escape sequences are replaced with
+    the characters they represent. `StringLiteral.raw` has been added and
+    stores the raw value as it was typed by the author of the string literal:
+    escapes sequences are not processed in any way.
+
   - Don't normalize line endings in `Junk`. (#184)
 
     Junk represents a literal slice of unparsed content and shouldn't have

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -115,6 +115,9 @@ export function into(Type) {
                 }
                 return always(new Type(expression));
             };
+        case FTL.StringLiteral:
+            return raw =>
+                always(new Type(raw, unescape(raw)));
         default:
             return (...args) =>
                 always(new Type(...args));
@@ -213,4 +216,29 @@ function remove_empty_text(element) {
 
 function remove_blank_lines(element) {
     return typeof(element) !== "string";
+}
+
+const KNOWN_ESCAPES = /(?:\\\\|\\\"|\\u([0-9a-fA-F]{4}))/g;
+
+function unescape(raw) {
+    return raw.replace(KNOWN_ESCAPES, from_escape_sequence);
+}
+
+function from_escape_sequence(match, group1) {
+    switch (match) {
+        case "\\\\":
+            return "\\";
+        case "\\\"":
+            return "\"";
+        default:
+            let codepoint = parseInt(group1, 16);
+            if (codepoint <= 0xD7FF || 0xE000 <= codepoint) {
+                // It's a Unicode scalar value.
+                return String.fromCodePoint(codepoint);
+            }
+            // Escape sequences reresenting surrogate code points are
+            // well-formed but invalid in Fluent. Replace them with U+FFFD
+            // REPLACEMENT CHARACTER.
+            return "�";
+    }
 }

--- a/syntax/ast.mjs
+++ b/syntax/ast.mjs
@@ -82,9 +82,10 @@ export class Placeable extends PatternElement {
 export class Expression extends SyntaxNode {}
 
 export class StringLiteral extends Expression {
-    constructor(value) {
+    constructor(raw, value) {
         super();
         this.type = "StringLiteral";
+        this.raw = raw;
         this.value = value;
     }
 }

--- a/syntax/ast.mjs
+++ b/syntax/ast.mjs
@@ -81,6 +81,12 @@ export class Placeable extends PatternElement {
 // An abstract base class for Expressions.
 export class Expression extends SyntaxNode {}
 
+// The "raw" field contains the exact contents of the string literal,
+// character-for-character. Escape sequences are stored verbatim without
+// processing. The "value" field contains the same contents with escape
+// sequences unescaped to the characters they represent.
+// See grammar.mjs for the definitions of well-formed escape sequences and
+// abstract.mjs for the validation and unescaping logic.
 export class StringLiteral extends Expression {
     constructor(raw, value) {
         super();

--- a/test/fixtures/astral.json
+++ b/test/fixtures/astral.json
@@ -68,7 +68,8 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
-                            "value": "\\uD83D\\uDE02"
+                            "raw": "\\uD83D\\uDE02",
+                            "value": "��"
                         }
                     }
                 ]
@@ -89,14 +90,16 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
-                            "value": "\\uD83D"
+                            "raw": "\\uD83D",
+                            "value": "�"
                         }
                     },
                     {
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
-                            "value": "\\uDE02"
+                            "raw": "\\uDE02",
+                            "value": "�"
                         }
                     }
                 ]
@@ -135,6 +138,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "A face 😂 with tears of joy.",
                             "value": "A face 😂 with tears of joy."
                         }
                     }

--- a/test/fixtures/call_expressions.json
+++ b/test/fixtures/call_expressions.json
@@ -101,6 +101,7 @@
                                 },
                                 {
                                     "type": "StringLiteral",
+                                    "raw": "a",
                                     "value": "a"
                                 },
                                 {
@@ -160,6 +161,7 @@
                                     },
                                     "value": {
                                         "type": "StringLiteral",
+                                        "raw": "Y",
                                         "value": "Y"
                                     }
                                 }
@@ -212,6 +214,7 @@
                                     },
                                     "value": {
                                         "type": "StringLiteral",
+                                        "raw": "Y",
                                         "value": "Y"
                                     }
                                 }
@@ -250,6 +253,7 @@
                                 },
                                 {
                                     "type": "StringLiteral",
+                                    "raw": "a",
                                     "value": "a"
                                 },
                                 {
@@ -280,6 +284,7 @@
                                     },
                                     "value": {
                                         "type": "StringLiteral",
+                                        "raw": "Y",
                                         "value": "Y"
                                     }
                                 }
@@ -336,6 +341,7 @@
                             "positional": [
                                 {
                                     "type": "StringLiteral",
+                                    "raw": "a",
                                     "value": "a"
                                 },
                                 {
@@ -418,6 +424,7 @@
                             "positional": [
                                 {
                                     "type": "StringLiteral",
+                                    "raw": "a",
                                     "value": "a"
                                 },
                                 {
@@ -471,6 +478,7 @@
                             "positional": [
                                 {
                                     "type": "StringLiteral",
+                                    "raw": "a",
                                     "value": "a"
                                 },
                                 {
@@ -587,6 +595,7 @@
                             "positional": [
                                 {
                                     "type": "StringLiteral",
+                                    "raw": "a",
                                     "value": "a"
                                 }
                             ],

--- a/test/fixtures/escaped_characters.json
+++ b/test/fixtures/escaped_characters.json
@@ -122,7 +122,8 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
-                            "value": "\\\""
+                            "raw": "\\\"",
+                            "value": "\""
                         }
                     }
                 ]
@@ -143,7 +144,8 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
-                            "value": "\\\\"
+                            "raw": "\\\\",
+                            "value": "\\"
                         }
                     }
                 ]
@@ -186,7 +188,8 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
-                            "value": "\\u0041"
+                            "raw": "\\u0041",
+                            "value": "A"
                         }
                     }
                 ]
@@ -207,7 +210,8 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
-                            "value": "\\\\u0041"
+                            "raw": "\\\\u0041",
+                            "value": "\\u0041"
                         }
                     }
                 ]
@@ -236,6 +240,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "{",
                             "value": "{"
                         }
                     },
@@ -265,6 +270,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "}",
                             "value": "}"
                         }
                     },

--- a/test/fixtures/leading_dots.json
+++ b/test/fixtures/leading_dots.json
@@ -50,6 +50,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": ".",
                             "value": "."
                         }
                     },
@@ -75,6 +76,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": ".",
                             "value": "."
                         }
                     },
@@ -104,6 +106,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": ".",
                             "value": "."
                         }
                     },
@@ -133,6 +136,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": ".",
                             "value": "."
                         }
                     },
@@ -229,6 +233,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": ".",
                             "value": "."
                         }
                     },
@@ -316,6 +321,7 @@
                                 "type": "Placeable",
                                 "expression": {
                                     "type": "StringLiteral",
+                                    "raw": ".",
                                     "value": "."
                                 }
                             },
@@ -377,6 +383,7 @@
                                                 "type": "Placeable",
                                                 "expression": {
                                                     "type": "StringLiteral",
+                                                    "raw": ".",
                                                     "value": "."
                                                 }
                                             },
@@ -463,6 +470,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": ".",
                             "value": "."
                         }
                     },

--- a/test/fixtures/literal_expressions.json
+++ b/test/fixtures/literal_expressions.json
@@ -14,6 +14,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "abc",
                             "value": "abc"
                         }
                     }

--- a/test/fixtures/messages.json
+++ b/test/fixtures/messages.json
@@ -218,6 +218,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "",
                             "value": ""
                         }
                     }

--- a/test/fixtures/multiline_values.json
+++ b/test/fixtures/multiline_values.json
@@ -126,6 +126,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "placeables",
                             "value": "placeables"
                         }
                     },
@@ -137,6 +138,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "at",
                             "value": "at"
                         }
                     },
@@ -148,6 +150,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "of lines",
                             "value": "of lines"
                         }
                     },
@@ -155,6 +158,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": ".",
                             "value": "."
                         }
                     }
@@ -176,6 +180,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "A multiline value",
                             "value": "A multiline value"
                         }
                     },
@@ -187,6 +192,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "with a placeable",
                             "value": "with a placeable"
                         }
                     }

--- a/test/fixtures/multiline_values.json
+++ b/test/fixtures/multiline_values.json
@@ -286,6 +286,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": ".",
                             "value": "."
                         }
                     },
@@ -315,6 +316,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": ".",
                             "value": "."
                         }
                     }

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -57,6 +57,7 @@
                                                 "type": "Placeable",
                                                 "expression": {
                                                     "type": "StringLiteral",
+                                                    "raw": "",
                                                     "value": ""
                                                 }
                                             },
@@ -169,6 +170,7 @@
                                                 "type": "Placeable",
                                                 "expression": {
                                                     "type": "StringLiteral",
+                                                    "raw": "",
                                                     "value": ""
                                                 }
                                             }

--- a/test/fixtures/terms.json
+++ b/test/fixtures/terms.json
@@ -49,6 +49,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "StringLiteral",
+                            "raw": "",
                             "value": ""
                         }
                     }


### PR DESCRIPTION
This also forbids escape sequences representing surrogate code points, following @Pike's suggestion from https://github.com/projectfluent/fluent/issues/194#issue-372533250. If we allow them, then their handling becomes environment/implementation dependent. E.g. they are ill-formed in the UTF-8 encoding.