### PR TITLE
Make Messages and Functions be in the same namespace

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -55,31 +55,33 @@ block_placeable     ::= blank_block blank_inline? inline_placeable
  * syntax/abstract.mjs. */
 InlineExpression    ::= StringLiteral
                       | NumberLiteral
-                      | VariableReference
                       | CallExpression
                       | AttributeExpression
                       | VariantExpression
-                      | MessageReference
-                      | TermReference
+                      | ReferenceExpression
                       | inline_placeable
 
 /* Literals */
 StringLiteral       ::= "\"" quoted_char* "\""
 NumberLiteral       ::= "-"? digit+ ("." digit+)?
 
-/* Inline Expressions */
+/* Reference Expressions */
+ReferenceExpression ::= FunctionReference
+                      | MessageReference
+                      | TermReference
+                      | VariableReference
 MessageReference    ::= Identifier
 TermReference       ::= "-" Identifier
 VariableReference   ::= "$" Identifier
 FunctionReference   ::= Identifier
-CallExpression      ::= Callee blank? "(" blank? argument_list blank? ")"
-Callee              ::= FunctionReference
-                      | TermReference
+
+/* Complex Expressions */
+CallExpression      ::= ReferenceExpression blank? "(" blank? argument_list blank? ")"
 argument_list       ::= (Argument blank? "," blank?)* Argument?
 Argument            ::= NamedArgument
                       | InlineExpression
 NamedArgument       ::= Identifier blank? ":" blank? (StringLiteral | NumberLiteral)
-AttributeExpression ::= (MessageReference | TermReference) "." Identifier
+AttributeExpression ::= ReferenceExpression "." Identifier
 /* DEPRECATION NOTICE VariantExpressions have been deprecated in Syntax 0.8. */
 VariantExpression   ::= TermReference VariantKey
 

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -8,8 +8,20 @@
 import * as FTL from "./ast.mjs";
 import {always, never} from "../lib/combinators.mjs";
 
+const VALID_FUNCTION_NAME = /^[A-Z][A-Z0-9_?-]*$/;
+
 export function list_into(Type) {
     switch (Type) {
+        case FTL.AttributeExpression:
+            return ([ref, name]) => {
+                let ref_is_valid =
+                    ref instanceof FTL.MessageReference
+                    || ref instanceof FTL.TermReference;
+                if (ref_is_valid) {
+                    return always(new Type(ref, name));
+                }
+                return never(`Invalid ref type: ${ref.type}.`);
+            };
         case FTL.Comment:
             return ([sigil, content = ""]) => {
                 switch (sigil) {
@@ -20,11 +32,17 @@ export function list_into(Type) {
                     case "###":
                         return always(new FTL.ResourceComment(content));
                     default:
-                        return never(`Unknown comment sigil: ${sigil}`);
+                        return never(`Unknown comment sigil: ${sigil}.`);
                 }
             };
         case FTL.CallExpression:
             return ([callee, args]) => {
+                let callee_is_valid =
+                    callee instanceof FTL.FunctionReference
+                    || callee instanceof FTL.TermReference;
+                if (!callee_is_valid) {
+                    return never(`Invalid callee type: ${callee.type}.`);
+                }
                 let positional_args = [];
                 let named_map = new Map();
                 for (let arg of args) {
@@ -45,6 +63,16 @@ export function list_into(Type) {
                 let named_args = Array.from(named_map.values());
                 return always(new Type(callee, positional_args, named_args));
             };
+        case FTL.Message:
+            return ([identifier, value, attributes]) => {
+                if (VALID_FUNCTION_NAME.test(identifier.name)) {
+                    return never(
+                        `Invalid message identifier: ${identifier.name}. `
+                        + "Message identifiers must not be all uppercase "
+                        + "ASCII letters.");
+                }
+                return always(new Type(identifier, value, attributes));
+            };
         case FTL.Pattern:
             return elements =>
                 always(new FTL.Pattern(
@@ -64,17 +92,19 @@ export function list_into(Type) {
                         .filter(remove_blank_lines)));
         case FTL.SelectExpression:
             return ([selector, variants]) => {
-                let invalid_selector_found =
-                    selector instanceof FTL.MessageReference
-                    || selector instanceof FTL.TermReference
+                let selector_is_valid =
+                    selector instanceof FTL.StringLiteral
+                    || selector instanceof FTL.NumberLiteral
+                    || selector instanceof FTL.VariableReference
                     || (selector instanceof FTL.CallExpression
-                        && selector.callee instanceof FTL.TermReference)
-                    || selector instanceof FTL.VariantExpression
+                        && selector.callee instanceof FTL.FunctionReference)
                     || (selector instanceof FTL.AttributeExpression
-                        && selector.ref instanceof FTL.MessageReference);
-                if (invalid_selector_found) {
+                        && selector.ref instanceof FTL.TermReference);
+                if (!selector_is_valid) {
                     return never(`Invalid selector type: ${selector.type}.`);
                 }
+
+                // DEPRECATED
                 let invalid_variants_found = variants.some(
                     variant => variant.value instanceof FTL.VariantList);
                 if (invalid_variants_found) {
@@ -82,6 +112,7 @@ export function list_into(Type) {
                         "VariantLists are only allowed inside of " +
                         "other VariantLists.");
                 }
+
                 return always(new Type(selector, variants));
             };
         case FTL.VariantList:
@@ -96,20 +127,20 @@ export function list_into(Type) {
 export function into(Type) {
     switch (Type) {
         case FTL.FunctionReference:
-            const VALID_FUNCTION_NAME = /^[A-Z][A-Z0-9_?-]*$/;
             return identifier => {
-                if (!VALID_FUNCTION_NAME.test(identifier.name)) {
-                    return never(
-                        `Invalid function name: ${identifier.name}. ` +
-                        "Function names must be upper-case.");
+                if (VALID_FUNCTION_NAME.test(identifier.name)) {
+                    return always(new Type(identifier));
                 }
-                return always(new Type(identifier));
+                return never(
+                    `Invalid function name: ${identifier.name}. `
+                    + "Function names must be all upper-case ASCII letters.");
             };
         case FTL.Placeable:
             return expression => {
                 let invalid_expression_found =
-                    expression instanceof FTL.AttributeExpression
-                    && expression.ref instanceof FTL.TermReference;
+                    expression instanceof FTL.FunctionReference
+                    || (expression instanceof FTL.AttributeExpression
+                        && expression.ref instanceof FTL.TermReference);
                 if (invalid_expression_found) {
                     return never(
                         `Invalid expression type: ${expression.type}.`);

--- a/test/fixtures/messages.ftl
+++ b/test/fixtures/messages.ftl
@@ -25,3 +25,6 @@ key07 =
 
 # JUNK Missing =
 key08
+
+# JUNK Message names must not be all uppercase ASCII letters.
+KEY09 = Value 09

--- a/test/fixtures/messages.json
+++ b/test/fixtures/messages.json
@@ -243,7 +243,16 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "key08\n"
+            "content": "key08\n\n"
+        },
+        {
+            "type": "Comment",
+            "content": "JUNK Message names must not be all uppercase ASCII letters."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "KEY09 = Value 09"
         }
     ]
 }

--- a/test/fixtures/reference_expressions.ftl
+++ b/test/fixtures/reference_expressions.ftl
@@ -2,4 +2,5 @@ message-reference = {msg}
 term-reference = {-term}
 variable-reference = {$var}
 
+# ERROR Function references are invalid outside of call expressions.
 not-call-expression = {FUN}

--- a/test/fixtures/reference_expressions.json
+++ b/test/fixtures/reference_expressions.json
@@ -74,28 +74,13 @@
             "comment": null
         },
         {
-            "type": "Message",
-            "id": {
-                "type": "Identifier",
-                "name": "not-call-expression"
-            },
-            "value": {
-                "type": "Pattern",
-                "elements": [
-                    {
-                        "type": "Placeable",
-                        "expression": {
-                            "type": "MessageReference",
-                            "id": {
-                                "type": "Identifier",
-                                "name": "FUN"
-                            }
-                        }
-                    }
-                ]
-            },
-            "attributes": [],
-            "comment": null
+            "type": "Comment",
+            "content": "ERROR Function references are invalid outside of call expressions."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "not-call-expression = {FUN}\n"
         }
     ]
 }


### PR DESCRIPTION
Forbid all uppercase ASCII identifiers for `Messages` and effectively make Messages and Functions co-exist in the same namespace.

```properties
## BEFORE

# FUNC is a FunctionReference
one = {FUNC()}
# FUNC is a MessageReference
two = {FUNC.attr}
```

With a single namespace for both Messages and Functions, `two` becomes a syntax error.

```properties
## AFTER

# FUNC is a FunctionReference
one = {FUNC()}
# FUNC is still a FunctionReference → Syntax Error
# (FunctionReference is not a valid `ref` of an `AttributeExpression`.)
two = {FUNC.attr}
```