### PR TITLE
Change line endings in comments to line_end

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -16,7 +16,8 @@ Term                ::= "-" Identifier blank_inline? "=" blank_inline? Value Att
 
 /* Adjacent comment lines of the same comment type are joined together during
  * the AST construction. */
-CommentLine         ::= ("###" | "##" | "#") ("\u0020" /.*/)? line_end
+CommentLine         ::= ("###" | "##" | "#") ("\u0020" comment_char*)? line_end
+comment_char        ::= any_char - line_end
 
 /* Junk represents unparsed content.
  *

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -78,11 +78,17 @@ let CommentLine = defer(() =>
         maybe(
             sequence(
                 string(" "),
-                regex(/.*/).abstract)),
+                repeat(comment_char)
+                    .map(join).abstract)),
         line_end)
     .map(flatten(1))
     .map(keep_abstract)
     .chain(list_into(FTL.Comment)));
+
+let comment_char = defer(() =>
+    and(
+        not(line_end),
+        any_char));
 
 /* -------------------------------------------------------------------------- */
 /* Junk represents unparsed content.

--- a/test/fixtures/cr.json
+++ b/test/fixtures/cr.json
@@ -2,9 +2,8 @@
     "type": "Resource",
     "body": [
         {
-            "type": "Junk",
-            "annotations": [],
-            "content": "### This entire file uses CR as EOL.\r\rerr01 = Value 01\rerr02 = Value 02\r\rerr03 =\r\r    Value 03\r    Continued\r\r    .title = Title\r\rerr04 = { \"str\r\rerr05 = { $sel -> }\r"
+            "type": "ResourceComment",
+            "content": "This entire file uses CR as EOL.\r\rerr01 = Value 01\rerr02 = Value 02\r\rerr03 =\r\r    Value 03\r    Continued\r\r    .title = Title\r\rerr04 = { \"str\r\rerr05 = { $sel -> }\r"
         }
     ]
 }


### PR DESCRIPTION
The `/.*/` regex doesn't match any of the line endings recognized by the JS RegExp engine, i.e. `\n`, `\r`, `\u2028`, `\u2029`. These are different from the line endings supported by the rest of the Fluent Syntax. This change unifies the line endings in all grammar productions.