### PR TITLE
Forbid nested VariantLists

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -31,7 +31,7 @@ junk_line           ::= /[^\n]*/ ("\u000A" | EOF)
 /* Attributes of Messages and Terms. */
 Attribute           ::= line_end blank? "." Identifier blank_inline? "=" blank_inline? Pattern
 
-/* Value types: Pattern and VariantList. */
+/* Value types: Pattern and VariantList (deprecated). */
 Value               ::= Pattern
                       | VariantList
 Pattern             ::= PatternElement+
@@ -88,8 +88,8 @@ VariantExpression   ::= TermReference VariantKey
 /* Block Expressions */
 SelectExpression    ::= InlineExpression blank? "->" blank_inline? variant_list
 variant_list        ::= Variant* DefaultVariant Variant* line_end
-Variant             ::= line_end blank? VariantKey blank_inline? Value
-DefaultVariant      ::= line_end blank? "*" VariantKey blank_inline? Value
+Variant             ::= line_end blank? VariantKey blank_inline? Pattern
+DefaultVariant      ::= line_end blank? "*" VariantKey blank_inline? Pattern
 VariantKey          ::= "[" blank? (NumberLiteral | Identifier) blank? "]"
 
 /* Identifier */

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -96,15 +96,6 @@ export function list_into(Type) {
                     return never(`Invalid selector type: ${selector.type}.`);
                 }
 
-                // DEPRECATED
-                let invalid_variants_found = variants.some(
-                    variant => variant.value instanceof FTL.VariantList);
-                if (invalid_variants_found) {
-                    return never(
-                        "VariantLists are only allowed inside of " +
-                        "other VariantLists.");
-                }
-
                 return always(new Type(selector, variants));
             };
         case FTL.VariantList:

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -133,8 +133,8 @@ let Attribute = defer(() =>
     .map(keep_abstract)
     .chain(list_into(FTL.Attribute)));
 
-/* ------------------------------------- */
-/* Value types: Pattern and VariantList. */
+/* -------------------------------------------------- */
+/* Value types: Pattern and VariantList (deprecated). */
 let Value = defer(() =>
     either(
         Pattern,
@@ -357,7 +357,7 @@ let Variant = defer(() =>
         maybe(blank),
         VariantKey.abstract,
         maybe(blank_inline),
-        Value.abstract)
+        Pattern.abstract)
     .map(keep_abstract)
     .chain(list_into(FTL.Variant)));
 
@@ -368,7 +368,7 @@ let DefaultVariant = defer(() =>
         string("*"),
         VariantKey.abstract,
         maybe(blank_inline),
-        Value.abstract)
+        Pattern.abstract)
     .map(keep_abstract)
     .chain(list_into(FTL.Variant))
     .map(mutate({default: true})));

--- a/test/fixtures/select_expressions.ftl
+++ b/test/fixtures/select_expressions.ftl
@@ -39,7 +39,7 @@ nested-select =
        }
     }
 
-# ERROR VariantLists cannot appear in SelectExpressions
+# ERROR VariantLists cannot be Variant values.
 nested-variant-list =
     { 1 ->
        *[one] {

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -274,7 +274,7 @@
         },
         {
             "type": "Comment",
-            "content": "ERROR VariantLists cannot appear in SelectExpressions"
+            "content": "ERROR VariantLists cannot be Variant values."
         },
         {
             "type": "Junk",

--- a/test/fixtures/variant_lists.ftl
+++ b/test/fixtures/variant_lists.ftl
@@ -23,6 +23,7 @@ variant-list-in-message-attr = Value
            *[key] Value
         }
 
+# ERROR VariantLists cannot be Variant values.
 -nested-variant-list-in-term =
     {
        *[one] {
@@ -37,7 +38,7 @@ variant-list-in-message-attr = Value
        }
     }
 
-# ERROR VariantLists may not appear in SelectExpressions
+# ERROR VariantLists cannot be Variant values.
 nested-select-then-variant-list =
     {
        *[one] { 2 ->

--- a/test/fixtures/variant_lists.json
+++ b/test/fixtures/variant_lists.json
@@ -94,48 +94,13 @@
             "content": "    .attr =\n        {\n           *[key] Value\n        }\n\n"
         },
         {
-            "type": "Term",
-            "id": {
-                "type": "Identifier",
-                "name": "nested-variant-list-in-term"
-            },
-            "value": {
-                "type": "VariantList",
-                "variants": [
-                    {
-                        "type": "Variant",
-                        "key": {
-                            "type": "Identifier",
-                            "name": "one"
-                        },
-                        "value": {
-                            "type": "VariantList",
-                            "variants": [
-                                {
-                                    "type": "Variant",
-                                    "key": {
-                                        "type": "Identifier",
-                                        "name": "two"
-                                    },
-                                    "value": {
-                                        "type": "Pattern",
-                                        "elements": [
-                                            {
-                                                "type": "TextElement",
-                                                "value": "Value"
-                                            }
-                                        ]
-                                    },
-                                    "default": true
-                                }
-                            ]
-                        },
-                        "default": true
-                    }
-                ]
-            },
-            "attributes": [],
-            "comment": null
+            "type": "Comment",
+            "content": "ERROR VariantLists cannot be Variant values."
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "-nested-variant-list-in-term =\n    {\n       *[one] {\n          *[two] Value\n       }\n    }\n\n"
         },
         {
             "type": "Term",
@@ -195,7 +160,7 @@
         },
         {
             "type": "Comment",
-            "content": "ERROR VariantLists may not appear in SelectExpressions"
+            "content": "ERROR VariantLists cannot be Variant values."
         },
         {
             "type": "Junk",


### PR DESCRIPTION
Nested `VariantLists` cannot be accessed anyways and `VariantLists` are deprecated and slated for removal before 1.0.