### PR TITLE
 Store attribute access and call args on reference expressions 

### DIFF
--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -52,11 +52,7 @@ block_placeable     ::= blank_block blank_inline? inline_placeable
  * syntax/abstract.mjs. */
 InlineExpression    ::= StringLiteral
                       | NumberLiteral
-                      | CallExpression
-                      | AttributeExpression
-                      | MessageReference
-                      | TermReference
-                      | VariableReference
+                      | ReferenceExpression
                       | inline_placeable
 
 /* Literals */
@@ -64,19 +60,20 @@ StringLiteral       ::= "\"" quoted_char* "\""
 NumberLiteral       ::= "-"? digit+ ("." digit+)?
 
 /* Inline Expressions */
-MessageReference    ::= Identifier
-TermReference       ::= "-" Identifier
-VariableReference   ::= "$" Identifier
-CallExpression      ::= CalleeExpression blank? "(" blank? argument_list blank? ")"
-CalleeExpression    ::= AttributeExpression
-                      | FunctionReference
+ReferenceExpression ::= FunctionReference
+                      | MessageReference
                       | TermReference
-FunctionReference   ::= Identifier
+                      | VariableReference
+FunctionReference   ::= Identifier CallArguments
+MessageReference    ::= Identifier AttributeAccessor?
+TermReference       ::= "-" Identifier AttributeAccessor? CallArguments?
+VariableReference   ::= "$" Identifier
+AttributeAccessor   ::= "." Identifier
+CallArguments       ::= blank? "(" blank? argument_list blank? ")"
 argument_list       ::= (Argument blank? "," blank?)* Argument?
 Argument            ::= NamedArgument
                       | InlineExpression
 NamedArgument       ::= Identifier blank? ":" blank? (StringLiteral | NumberLiteral)
-AttributeExpression ::= (MessageReference | TermReference) "." Identifier
 
 /* Block Expressions */
 SelectExpression    ::= InlineExpression blank? "->" blank_inline? variant_list

--- a/syntax/ast.mjs
+++ b/syntax/ast.mjs
@@ -97,18 +97,21 @@ export class NumberLiteral extends Expression {
 }
 
 export class MessageReference extends Expression {
-    constructor(id) {
+    constructor(id, attribute) {
         super();
         this.type = "MessageReference";
         this.id = id;
+        this.attribute = attribute;
     }
 }
 
 export class TermReference extends Expression {
-    constructor(id) {
+    constructor(id, attribute, args) {
         super();
         this.type = "TermReference";
         this.id = id;
+        this.attribute = attribute;
+        this.args = args;
     }
 }
 
@@ -121,10 +124,11 @@ export class VariableReference extends Expression {
 }
 
 export class FunctionReference extends Expression {
-    constructor(id) {
+    constructor(id, args) {
         super();
         this.type = "FunctionReference";
         this.id = id;
+        this.args = args;
     }
 }
 
@@ -134,25 +138,6 @@ export class SelectExpression extends Expression {
         this.type = "SelectExpression";
         this.selector = selector;
         this.variants = variants;
-    }
-}
-
-export class AttributeExpression extends Expression {
-    constructor(ref, name) {
-        super();
-        this.type = "AttributeExpression";
-        this.ref = ref;
-        this.name = name;
-    }
-}
-
-export class CallExpression extends Expression {
-    constructor(callee, positional = [], named = []) {
-        super();
-        this.type = "CallExpression";
-        this.callee = callee;
-        this.positional = positional;
-        this.named = named;
     }
 }
 
@@ -172,6 +157,15 @@ export class Variant extends SyntaxNode {
         this.key = key;
         this.value = value;
         this.default = def;
+    }
+}
+
+export class CallArguments extends SyntaxNode {
+    constructor(positional = [], named = []) {
+        super();
+        this.type = "CallArguments";
+        this.positional = positional;
+        this.named = named;
     }
 }
 

--- a/test/fixtures/call_expressions.json
+++ b/test/fixtures/call_expressions.json
@@ -17,33 +17,34 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "1"
-                                },
-                                {
-                                    "type": "StringLiteral",
-                                    "raw": "a",
-                                    "value": "a"
-                                },
-                                {
-                                    "type": "MessageReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "msg"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "type": "StringLiteral",
+                                        "raw": "a",
+                                        "value": "a"
+                                    },
+                                    {
+                                        "type": "MessageReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "msg"
+                                        },
+                                        "attribute": null
                                     }
-                                }
-                            ],
-                            "named": []
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -63,40 +64,40 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
                                     },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "y"
+                                        },
+                                        "value": {
+                                            "type": "StringLiteral",
+                                            "raw": "Y",
+                                            "value": "Y"
+                                        }
                                     }
-                                },
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "y"
-                                    },
-                                    "value": {
-                                        "type": "StringLiteral",
-                                        "raw": "Y",
-                                        "value": "Y"
-                                    }
-                                }
-                            ]
+                                ]
+                            }
                         }
                     }
                 ]
@@ -116,40 +117,40 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
                                     },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "y"
+                                        },
+                                        "value": {
+                                            "type": "StringLiteral",
+                                            "raw": "Y",
+                                            "value": "Y"
+                                        }
                                     }
-                                },
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "y"
-                                    },
-                                    "value": {
-                                        "type": "StringLiteral",
-                                        "raw": "Y",
-                                        "value": "Y"
-                                    }
-                                }
-                            ]
+                                ]
+                            }
                         }
                     }
                 ]
@@ -169,57 +170,58 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "1"
-                                },
-                                {
-                                    "type": "StringLiteral",
-                                    "raw": "a",
-                                    "value": "a"
-                                },
-                                {
-                                    "type": "MessageReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "msg"
-                                    }
-                                }
-                            ],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
-                                    },
-                                    "value": {
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
                                         "type": "NumberLiteral",
                                         "value": "1"
-                                    }
-                                },
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "y"
                                     },
-                                    "value": {
+                                    {
                                         "type": "StringLiteral",
-                                        "raw": "Y",
-                                        "value": "Y"
+                                        "raw": "a",
+                                        "value": "a"
+                                    },
+                                    {
+                                        "type": "MessageReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "msg"
+                                        },
+                                        "attribute": null
                                     }
-                                }
-                            ]
+                                ],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
+                                    },
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "y"
+                                        },
+                                        "value": {
+                                            "type": "StringLiteral",
+                                            "raw": "Y",
+                                            "value": "Y"
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 ]
@@ -261,41 +263,42 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "StringLiteral",
-                                    "raw": "a",
-                                    "value": "a"
-                                },
-                                {
-                                    "type": "MessageReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "msg"
-                                    }
-                                }
-                            ],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "StringLiteral",
+                                        "raw": "a",
+                                        "value": "a"
                                     },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                                    {
+                                        "type": "MessageReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "msg"
+                                        },
+                                        "attribute": null
                                     }
-                                }
-                            ]
+                                ],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 ]
@@ -315,16 +318,16 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -344,41 +347,42 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "StringLiteral",
-                                    "raw": "a",
-                                    "value": "a"
-                                },
-                                {
-                                    "type": "MessageReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "msg"
-                                    }
-                                }
-                            ],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "StringLiteral",
+                                        "raw": "a",
+                                        "value": "a"
                                     },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                                    {
+                                        "type": "MessageReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "msg"
+                                        },
+                                        "attribute": null
                                     }
-                                }
-                            ]
+                                ],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 ]
@@ -398,41 +402,42 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "StringLiteral",
-                                    "raw": "a",
-                                    "value": "a"
-                                },
-                                {
-                                    "type": "MessageReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "msg"
-                                    }
-                                }
-                            ],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "StringLiteral",
+                                        "raw": "a",
+                                        "value": "a"
                                     },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                                    {
+                                        "type": "MessageReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "msg"
+                                        },
+                                        "attribute": null
                                     }
-                                }
-                            ]
+                                ],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     }
                 ]
@@ -452,16 +457,16 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -481,21 +486,21 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "1"
-                                }
-                            ],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    }
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -515,22 +520,22 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "StringLiteral",
-                                    "raw": "a",
-                                    "value": "a"
-                                }
-                            ],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "StringLiteral",
+                                        "raw": "a",
+                                        "value": "a"
+                                    }
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -550,24 +555,25 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "MessageReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "msg"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "MessageReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "msg"
+                                        },
+                                        "attribute": null
                                     }
-                                }
-                            ],
-                            "named": []
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -587,24 +593,26 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "TermReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "msg"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "TermReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "msg"
+                                        },
+                                        "attribute": null,
+                                        "args": null
                                     }
-                                }
-                            ],
-                            "named": []
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -624,24 +632,24 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "VariableReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "var"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "VariableReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "var"
+                                        }
                                     }
-                                }
-                            ],
-                            "named": []
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -661,29 +669,29 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "CallExpression",
-                                    "callee": {
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
                                         "type": "FunctionReference",
                                         "id": {
                                             "type": "Identifier",
                                             "name": "OTHER"
+                                        },
+                                        "args": {
+                                            "type": "CallArguments",
+                                            "positional": [],
+                                            "named": []
                                         }
-                                    },
-                                    "positional": [],
-                                    "named": []
-                                }
-                            ],
-                            "named": []
+                                    }
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -703,28 +711,28 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
-                                    },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
                                     }
-                                }
-                            ]
+                                ]
+                            }
                         }
                     }
                 ]
@@ -744,24 +752,25 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "MessageReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "x"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "MessageReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "attribute": null
                                     }
-                                }
-                            ],
-                            "named": []
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -785,21 +794,21 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "1"
-                                }
-                            ],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    }
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -819,29 +828,29 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "1"
-                                },
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "2"
-                                },
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "3"
-                                }
-                            ],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "2"
+                                    },
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "3"
+                                    }
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -861,29 +870,29 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "1"
-                                },
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "2"
-                                },
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "3"
-                                }
-                            ],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "2"
+                                    },
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "3"
+                                    }
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -903,25 +912,25 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "1"
-                                },
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "2"
-                                }
-                            ],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "2"
+                                    }
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -941,25 +950,25 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "1"
-                                },
-                                {
-                                    "type": "NumberLiteral",
-                                    "value": "2"
-                                }
-                            ],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "1"
+                                    },
+                                    {
+                                        "type": "NumberLiteral",
+                                        "value": "2"
+                                    }
+                                ],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -1002,50 +1011,50 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
                                     },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
-                                    }
-                                },
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "y"
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "y"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "2"
+                                        }
                                     },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "2"
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "z"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "3"
+                                        }
                                     }
-                                },
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "z"
-                                    },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "3"
-                                    }
-                                }
-                            ]
+                                ]
+                            }
                         }
                     }
                 ]
@@ -1065,28 +1074,28 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
-                                    },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
                                     }
-                                }
-                            ]
+                                ]
+                            }
                         }
                     }
                 ]
@@ -1106,28 +1115,28 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUN"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
                             },
-                            "positional": [],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "x"
-                                    },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
                                     }
-                                }
-                            ]
+                                ]
+                            }
                         }
                     }
                 ]

--- a/test/fixtures/callee_expressions.json
+++ b/test/fixtures/callee_expressions.json
@@ -17,16 +17,16 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "FunctionReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "FUNCTION"
-                                }
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUNCTION"
                             },
-                            "positional": [],
-                            "named": []
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -46,16 +46,17 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "TermReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "term"
-                                }
+                            "type": "TermReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "term"
                             },
-                            "positional": [],
-                            "named": []
+                            "attribute": null,
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -126,16 +127,16 @@
                         "expression": {
                             "type": "SelectExpression",
                             "selector": {
-                                "type": "CallExpression",
-                                "callee": {
-                                    "type": "FunctionReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "FUNCTION"
-                                    }
+                                "type": "FunctionReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "FUNCTION"
                                 },
-                                "positional": [],
-                                "named": []
+                                "args": {
+                                    "type": "CallArguments",
+                                    "positional": [],
+                                    "named": []
+                                }
                             },
                             "variants": [
                                 {
@@ -177,23 +178,20 @@
                         "expression": {
                             "type": "SelectExpression",
                             "selector": {
-                                "type": "CallExpression",
-                                "callee": {
-                                    "type": "AttributeExpression",
-                                    "ref": {
-                                        "type": "TermReference",
-                                        "id": {
-                                            "type": "Identifier",
-                                            "name": "term"
-                                        }
-                                    },
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "attr"
-                                    }
+                                "type": "TermReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "term"
                                 },
-                                "positional": [],
-                                "named": []
+                                "attribute": {
+                                    "type": "Identifier",
+                                    "name": "attr"
+                                },
+                                "args": {
+                                    "type": "CallArguments",
+                                    "positional": [],
+                                    "named": []
+                                }
                             },
                             "variants": [
                                 {

--- a/test/fixtures/escaped_characters.json
+++ b/test/fixtures/escaped_characters.json
@@ -61,7 +61,8 @@
                             "id": {
                                 "type": "Identifier",
                                 "name": "placeable"
-                            }
+                            },
+                            "attribute": null
                         }
                     }
                 ]

--- a/test/fixtures/member_expressions.json
+++ b/test/fixtures/member_expressions.json
@@ -17,15 +17,12 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "AttributeExpression",
-                            "ref": {
-                                "type": "MessageReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "msg"
-                                }
+                            "type": "MessageReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "msg"
                             },
-                            "name": {
+                            "attribute": {
                                 "type": "Identifier",
                                 "name": "attr"
                             }
@@ -66,18 +63,16 @@
                         "expression": {
                             "type": "SelectExpression",
                             "selector": {
-                                "type": "AttributeExpression",
-                                "ref": {
-                                    "type": "TermReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "term"
-                                    }
+                                "type": "TermReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "term"
                                 },
-                                "name": {
+                                "attribute": {
                                     "type": "Identifier",
                                     "name": "attr"
-                                }
+                                },
+                                "args": null
                             },
                             "variants": [
                                 {

--- a/test/fixtures/reference_expressions.json
+++ b/test/fixtures/reference_expressions.json
@@ -21,7 +21,8 @@
                             "id": {
                                 "type": "Identifier",
                                 "name": "msg"
-                            }
+                            },
+                            "attribute": null
                         }
                     }
                 ]
@@ -45,7 +46,9 @@
                             "id": {
                                 "type": "Identifier",
                                 "name": "term"
-                            }
+                            },
+                            "attribute": null,
+                            "args": null
                         }
                     }
                 ]
@@ -93,7 +96,8 @@
                             "id": {
                                 "type": "Identifier",
                                 "name": "FUN"
-                            }
+                            },
+                            "attribute": null
                         }
                     }
                 ]

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -15,16 +15,16 @@
                         "expression": {
                             "type": "SelectExpression",
                             "selector": {
-                                "type": "CallExpression",
-                                "callee": {
-                                    "type": "FunctionReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "BUILTIN"
-                                    }
+                                "type": "FunctionReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "BUILTIN"
                                 },
-                                "positional": [],
-                                "named": []
+                                "args": {
+                                    "type": "CallArguments",
+                                    "positional": [],
+                                    "named": []
+                                }
                             },
                             "variants": [
                                 {
@@ -91,18 +91,16 @@
                         "expression": {
                             "type": "SelectExpression",
                             "selector": {
-                                "type": "AttributeExpression",
-                                "ref": {
-                                    "type": "TermReference",
-                                    "id": {
-                                        "type": "Identifier",
-                                        "name": "term"
-                                    }
+                                "type": "TermReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "term"
                                 },
-                                "name": {
+                                "attribute": {
                                     "type": "Identifier",
                                     "name": "case"
-                                }
+                                },
+                                "args": null
                             },
                             "variants": [
                                 {

--- a/test/fixtures/term_parameters.json
+++ b/test/fixtures/term_parameters.json
@@ -63,7 +63,9 @@
                             "id": {
                                 "type": "Identifier",
                                 "name": "term"
-                            }
+                            },
+                            "attribute": null,
+                            "args": null
                         }
                     }
                 ]
@@ -83,16 +85,17 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "TermReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "term"
-                                }
+                            "type": "TermReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "term"
                             },
-                            "positional": [],
-                            "named": []
+                            "attribute": null,
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": []
+                            }
                         }
                     }
                 ]
@@ -112,28 +115,29 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "TermReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "term"
-                                }
+                            "type": "TermReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "term"
                             },
-                            "positional": [],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "arg"
-                                    },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                            "attribute": null,
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "arg"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
                                     }
-                                }
-                            ]
+                                ]
+                            }
                         }
                     }
                 ]
@@ -153,45 +157,46 @@
                     {
                         "type": "Placeable",
                         "expression": {
-                            "type": "CallExpression",
-                            "callee": {
-                                "type": "TermReference",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "term"
-                                }
+                            "type": "TermReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "term"
                             },
-                            "positional": [
-                                {
-                                    "type": "StringLiteral",
-                                    "raw": "positional",
-                                    "value": "positional"
-                                }
-                            ],
-                            "named": [
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "narg1"
-                                    },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "1"
+                            "attribute": null,
+                            "args": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "StringLiteral",
+                                        "raw": "positional",
+                                        "value": "positional"
                                     }
-                                },
-                                {
-                                    "type": "NamedArgument",
-                                    "name": {
-                                        "type": "Identifier",
-                                        "name": "narg2"
+                                ],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "narg1"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "1"
+                                        }
                                     },
-                                    "value": {
-                                        "type": "NumberLiteral",
-                                        "value": "2"
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "narg2"
+                                        },
+                                        "value": {
+                                            "type": "NumberLiteral",
+                                            "value": "2"
+                                        }
                                     }
-                                }
-                            ]
+                                ]
+                            }
                         }
                     }
                 ]


### PR DESCRIPTION
Right now, we store complex member expressions as nested trees of AST nodes. As an example, a parameterized term attribute of the form `-term.attr(arg: "value")` parses as:

    CallExpression {
        callee: AttributeExpression {
            ref: TermReference {
                id: Identifier {name: "term"}
            },
            name: Identifier {name: "attr"}
        },
        positional: [],
        named: [NamedArgument {...}]
    }

This is a well established pattern in general-purpose languages. It is capable of handling deeply nested hierarchies of expressions. In Fluent, however, we only ever go so deep. All the possible nestings are known up-front and are defined by the grammar.

Furthermore, the above AST structure makes tooling harder. Checking for a `TermReference` means checking for four different AST structures (corresponding to `-term`, `-term()`, `-term.attr`, and `-term.attr()`).

In this PR, I've tried a different approach: the attribute access and the call arguments are stored on the reference node itself:

    TermReference {
        id: Identifier {name: "term"},
        attribute: Identifier {name: "attr"}
        args: CallArguments {
            positional: [],
            named: [NamedArgument {...}]
        }
    }

I implemented this approach for `MessageReference`, `TermReference`, `VariableReference` and `FunctionReference`.