### PR TITLE
Force checkouts of .ftl files to use LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+*.ftl eol=lf
 test/fixtures/crlf.ftl eol=crlf
 test/fixtures/cr.ftl eol=cr


### PR DESCRIPTION
(See https://github.com/projectfluent/fluent-rs/issues/83 for the original discussion.)


Fluent normalizes line endings of correctly parsed content to `LF`. If there are not syntax errors, all files regardless of their line endings are parsed into an AST in which the line endings inside of `TextElements` are normalized to `LF`.

This isn't true for `Junk`, however. In Syntax 0.8, we changed `Junk` to preserve exactly the characters of the unparsed content. If the file uses `CRLF`, the `Junk` content will have the `CRLF` as well.

Git can be [configured to normalize line endings on commit and on checkout](https://git-scm.com/docs/git-config#git-config-coreautocrlf). I have this option set to `core.autocrlf = input` globally, so even though I'm on Windows, my checkouts always use `LF` (unless overridden on a file-by-file basis in `.gitattributes`). That's why I've never seen this error. If I change this setting to <del>`false` or</del> `true`, I can reproduce it. (_Correction_: `autocrlf = false` checks out `LF` files, so the tests pass.)

I don't think it's reasonable to expect everyone cloning our repos to set this option to `input`. We should instead use `.gitattributes` to force git to checkout `.ftl` files with line endings which our tests expect.