### PR TITLE
Rename args to arguments

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -14,6 +14,11 @@
     the literal, thus allowing the AST to preserve the precision used in the
     source.
 
+  - Rename `args` to `arguments`.
+
+    The `args` field of `MessageReference`, `TermReference`,
+    `FunctionReference`, and `Annotation` has been renamed to `arguments`.
+
 ## 0.8.0 (December 13, 2018)
 
   - Preserve content-indent in multiline `Patterns`. (#162)

--- a/syntax/ast.mjs
+++ b/syntax/ast.mjs
@@ -112,7 +112,7 @@ export class TermReference extends Expression {
         this.type = "TermReference";
         this.id = id;
         this.attribute = attribute;
-        this.args = args;
+        this.arguments = args;
     }
 }
 
@@ -129,7 +129,7 @@ export class FunctionReference extends Expression {
         super();
         this.type = "FunctionReference";
         this.id = id;
-        this.args = args;
+        this.arguments = args;
     }
 }
 
@@ -242,7 +242,7 @@ export class Annotation extends SyntaxNode {
         super();
         this.type = "Annotation";
         this.code = code;
-        this.args = args;
+        this.arguments = args;
         this.message = message;
     }
 }

--- a/test/fixtures/call_expressions.json
+++ b/test/fixtures/call_expressions.json
@@ -22,7 +22,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -70,7 +70,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": [
@@ -124,7 +124,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": [
@@ -178,7 +178,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -273,7 +273,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -329,7 +329,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": []
@@ -358,7 +358,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -414,7 +414,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -470,7 +470,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": []
@@ -499,7 +499,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -534,7 +534,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -569,7 +569,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -607,7 +607,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -617,7 +617,7 @@
                                             "name": "msg"
                                         },
                                         "attribute": null,
-                                        "args": null
+                                        "arguments": null
                                     }
                                 ],
                                 "named": []
@@ -646,7 +646,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -683,7 +683,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -692,7 +692,7 @@
                                             "type": "Identifier",
                                             "name": "OTHER"
                                         },
-                                        "args": {
+                                        "arguments": {
                                             "type": "CallArguments",
                                             "positional": [],
                                             "named": []
@@ -725,7 +725,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": [
@@ -767,7 +767,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -809,7 +809,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -844,7 +844,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -889,7 +889,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -934,7 +934,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -974,7 +974,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {
@@ -1037,7 +1037,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": [
@@ -1103,7 +1103,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": [
@@ -1145,7 +1145,7 @@
                                 "type": "Identifier",
                                 "name": "FUN"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": [

--- a/test/fixtures/callee_expressions.json
+++ b/test/fixtures/callee_expressions.json
@@ -22,7 +22,7 @@
                                 "type": "Identifier",
                                 "name": "FUNCTION"
                             },
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": []
@@ -52,7 +52,7 @@
                                 "name": "term"
                             },
                             "attribute": null,
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": []
@@ -132,7 +132,7 @@
                                     "type": "Identifier",
                                     "name": "FUNCTION"
                                 },
-                                "args": {
+                                "arguments": {
                                     "type": "CallArguments",
                                     "positional": [],
                                     "named": []
@@ -187,7 +187,7 @@
                                     "type": "Identifier",
                                     "name": "attr"
                                 },
-                                "args": {
+                                "arguments": {
                                     "type": "CallArguments",
                                     "positional": [],
                                     "named": []

--- a/test/fixtures/member_expressions.json
+++ b/test/fixtures/member_expressions.json
@@ -72,7 +72,7 @@
                                     "type": "Identifier",
                                     "name": "attr"
                                 },
-                                "args": null
+                                "arguments": null
                             },
                             "variants": [
                                 {

--- a/test/fixtures/reference_expressions.json
+++ b/test/fixtures/reference_expressions.json
@@ -48,7 +48,7 @@
                                 "name": "term"
                             },
                             "attribute": null,
-                            "args": null
+                            "arguments": null
                         }
                     }
                 ]

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -20,7 +20,7 @@
                                     "type": "Identifier",
                                     "name": "BUILTIN"
                                 },
-                                "args": {
+                                "arguments": {
                                     "type": "CallArguments",
                                     "positional": [],
                                     "named": []
@@ -101,7 +101,7 @@
                                     "type": "Identifier",
                                     "name": "case"
                                 },
-                                "args": null
+                                "arguments": null
                             },
                             "variants": [
                                 {

--- a/test/fixtures/term_parameters.json
+++ b/test/fixtures/term_parameters.json
@@ -65,7 +65,7 @@
                                 "name": "term"
                             },
                             "attribute": null,
-                            "args": null
+                            "arguments": null
                         }
                     }
                 ]
@@ -91,7 +91,7 @@
                                 "name": "term"
                             },
                             "attribute": null,
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": []
@@ -121,7 +121,7 @@
                                 "name": "term"
                             },
                             "attribute": null,
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [],
                                 "named": [
@@ -164,7 +164,7 @@
                                 "name": "term"
                             },
                             "attribute": null,
-                            "args": {
+                            "arguments": {
                                 "type": "CallArguments",
                                 "positional": [
                                     {


### PR DESCRIPTION
The fields of our AST nodes are usually spelled out as full words. The only exception being the `id`, which I think is common enough to almost function on its own as a word, and `args`. This PR renames `args` to `arguments`, to match other names such as `attributes`, `annotations` etc.

For implementations, this has both upsides and downsides. In Python, we've seen how [`args` is a special attribute of `Exception`](https://github.com/projectfluent/python-fluent/pull/99#discussion_r256334364) which cannot be anything else than a tuple. In JavaScript, `arguments` may not be used as a variable binding in the strict mode. This would make destructuring assignment, such as in `let {id, arguments} = refNode;` impossible. The workaround is to use `refNode.arguments` directly, or to reassign the property: `let {id, arguments: args} = refNode`.