### PR TITLE
Revert changes to NumberLiteral from #232

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -7,13 +7,6 @@
     The `VariantLists` and the `VariantExpression` syntax and AST nodes were
     deprecated in Syntax 0.9 and have now been removed.
 
-  - Store `NumberLiterals` as floats with precision. (#232)
-
-    The `NumberLiteral.value` field is now a float value rather than a string.
-    A new field called `precision` stores the number of decimal places used in
-    the literal, thus allowing the AST to preserve the precision used in the
-    source.
-
   - Rename `args` to `arguments`.
 
     The `args` field of `MessageReference`, `TermReference`,

--- a/syntax/abstract.mjs
+++ b/syntax/abstract.mjs
@@ -94,13 +94,6 @@ export function into(Type) {
                 return always(new Type(
                     positional, Array.from(named.values())));
             };
-        case FTL.NumberLiteral:
-            return ([minus, integer, fraction = ""]) => {
-                let sign = minus ? "-" : "+";
-                let value = parseFloat(sign + integer + "." + fraction);
-                let precision = fraction.length;
-                return always(new Type(value, precision));
-            };
         case FTL.Placeable:
             return expression => {
                 if (expression instanceof FTL.TermReference

--- a/syntax/ast.mjs
+++ b/syntax/ast.mjs
@@ -89,11 +89,10 @@ export class StringLiteral extends Expression {
 }
 
 export class NumberLiteral extends Expression {
-    constructor(value, precision) {
+    constructor(value) {
         super();
         this.type = "NumberLiteral";
         this.value = value;
-        this.precision = precision;
     }
 }
 

--- a/syntax/grammar.mjs
+++ b/syntax/grammar.mjs
@@ -212,14 +212,14 @@ let StringLiteral = defer(() =>
 
 let NumberLiteral = defer(() =>
     sequence(
-        maybe(string("-")).abstract,
-        digits.abstract,
+        maybe(string("-")),
+        digits,
         maybe(
             sequence(
                 string("."),
-                digits.abstract)))
-    .map(flatten(2))
-    .map(keep_abstract)
+                digits)))
+    .map(flatten(1))
+    .map(join)
     .chain(into(FTL.NumberLiteral)));
 
 /* ------------------ */

--- a/test/fixtures/call_expressions.json
+++ b/test/fixtures/call_expressions.json
@@ -27,8 +27,7 @@
                                 "positional": [
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 1,
-                                        "precision": 0
+                                        "value": "1"
                                     },
                                     {
                                         "type": "StringLiteral",
@@ -82,8 +81,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     },
                                     {
@@ -136,8 +134,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     },
                                     {
@@ -183,8 +180,7 @@
                                 "positional": [
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 1,
-                                        "precision": 0
+                                        "value": "1"
                                     },
                                     {
                                         "type": "StringLiteral",
@@ -209,8 +205,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     },
                                     {
@@ -299,8 +294,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     }
                                 ]
@@ -384,8 +378,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     }
                                 ]
@@ -440,8 +433,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     }
                                 ]
@@ -504,8 +496,7 @@
                                 "positional": [
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 1,
-                                        "precision": 0
+                                        "value": "1"
                                     }
                                 ],
                                 "named": []
@@ -737,8 +728,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     }
                                 ]
@@ -814,8 +804,7 @@
                                 "positional": [
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 1,
-                                        "precision": 0
+                                        "value": "1"
                                     }
                                 ],
                                 "named": []
@@ -849,18 +838,15 @@
                                 "positional": [
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 1,
-                                        "precision": 0
+                                        "value": "1"
                                     },
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 2,
-                                        "precision": 0
+                                        "value": "2"
                                     },
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 3,
-                                        "precision": 0
+                                        "value": "3"
                                     }
                                 ],
                                 "named": []
@@ -894,18 +880,15 @@
                                 "positional": [
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 1,
-                                        "precision": 0
+                                        "value": "1"
                                     },
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 2,
-                                        "precision": 0
+                                        "value": "2"
                                     },
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 3,
-                                        "precision": 0
+                                        "value": "3"
                                     }
                                 ],
                                 "named": []
@@ -939,13 +922,11 @@
                                 "positional": [
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 1,
-                                        "precision": 0
+                                        "value": "1"
                                     },
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 2,
-                                        "precision": 0
+                                        "value": "2"
                                     }
                                 ],
                                 "named": []
@@ -979,13 +960,11 @@
                                 "positional": [
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 1,
-                                        "precision": 0
+                                        "value": "1"
                                     },
                                     {
                                         "type": "NumberLiteral",
-                                        "value": 2,
-                                        "precision": 0
+                                        "value": "2"
                                     }
                                 ],
                                 "named": []
@@ -1049,8 +1028,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     },
                                     {
@@ -1061,8 +1039,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 2,
-                                            "precision": 0
+                                            "value": "2"
                                         }
                                     },
                                     {
@@ -1073,8 +1050,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 3,
-                                            "precision": 0
+                                            "value": "3"
                                         }
                                     }
                                 ]
@@ -1115,8 +1091,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     }
                                 ]
@@ -1157,8 +1132,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     }
                                 ]

--- a/test/fixtures/leading_dots.json
+++ b/test/fixtures/leading_dots.json
@@ -350,8 +350,7 @@
                             "type": "SelectExpression",
                             "selector": {
                                 "type": "NumberLiteral",
-                                "value": 1,
-                                "precision": 0
+                                "value": "1"
                             },
                             "variants": [
                                 {

--- a/test/fixtures/literal_expressions.json
+++ b/test/fixtures/literal_expressions.json
@@ -36,8 +36,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 123,
-                            "precision": 0
+                            "value": "123"
                         }
                     }
                 ]
@@ -58,8 +57,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": -3.14,
-                            "precision": 2
+                            "value": "-3.14"
                         }
                     }
                 ]

--- a/test/fixtures/numbers.json
+++ b/test/fixtures/numbers.json
@@ -14,8 +14,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 0,
-                            "precision": 0
+                            "value": "0"
                         }
                     }
                 ]
@@ -36,8 +35,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 1,
-                            "precision": 0
+                            "value": "1"
                         }
                     }
                 ]
@@ -58,8 +56,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": -1,
-                            "precision": 0
+                            "value": "-1"
                         }
                     }
                 ]
@@ -80,8 +77,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 0,
-                            "precision": 0
+                            "value": "-0"
                         }
                     }
                 ]
@@ -102,8 +98,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 1,
-                            "precision": 0
+                            "value": "01"
                         }
                     }
                 ]
@@ -124,8 +119,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": -1,
-                            "precision": 0
+                            "value": "-01"
                         }
                     }
                 ]
@@ -146,8 +140,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 0,
-                            "precision": 0
+                            "value": "00"
                         }
                     }
                 ]
@@ -168,8 +161,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 0,
-                            "precision": 0
+                            "value": "-00"
                         }
                     }
                 ]
@@ -190,8 +182,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 0,
-                            "precision": 1
+                            "value": "0.0"
                         }
                     }
                 ]
@@ -212,8 +203,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 0.01,
-                            "precision": 2
+                            "value": "0.01"
                         }
                     }
                 ]
@@ -234,8 +224,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 1.03,
-                            "precision": 2
+                            "value": "1.03"
                         }
                     }
                 ]
@@ -256,8 +245,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 1,
-                            "precision": 3
+                            "value": "1.000"
                         }
                     }
                 ]
@@ -278,8 +266,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": -0.01,
-                            "precision": 2
+                            "value": "-0.01"
                         }
                     }
                 ]
@@ -300,8 +287,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": -1.03,
-                            "precision": 2
+                            "value": "-1.03"
                         }
                     }
                 ]
@@ -322,8 +308,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 0,
-                            "precision": 1
+                            "value": "-0.0"
                         }
                     }
                 ]
@@ -344,8 +329,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": -1,
-                            "precision": 3
+                            "value": "-1.000"
                         }
                     }
                 ]
@@ -366,8 +350,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 1.03,
-                            "precision": 2
+                            "value": "01.03"
                         }
                     }
                 ]
@@ -388,8 +371,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 1.03,
-                            "precision": 4
+                            "value": "1.0300"
                         }
                     }
                 ]
@@ -410,8 +392,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 1.03,
-                            "precision": 4
+                            "value": "01.0300"
                         }
                     }
                 ]
@@ -432,8 +413,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": -1.03,
-                            "precision": 2
+                            "value": "-01.03"
                         }
                     }
                 ]
@@ -454,8 +434,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": -1.03,
-                            "precision": 4
+                            "value": "-1.0300"
                         }
                     }
                 ]
@@ -476,8 +455,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": -1.03,
-                            "precision": 4
+                            "value": "-01.0300"
                         }
                     }
                 ]

--- a/test/fixtures/placeables.json
+++ b/test/fixtures/placeables.json
@@ -18,8 +18,7 @@
                                 "type": "Placeable",
                                 "expression": {
                                     "type": "NumberLiteral",
-                                    "value": 1,
-                                    "precision": 0
+                                    "value": "1"
                                 }
                             }
                         }
@@ -42,8 +41,7 @@
                         "type": "Placeable",
                         "expression": {
                             "type": "NumberLiteral",
-                            "value": 1,
-                            "precision": 0
+                            "value": "1"
                         }
                     }
                 ]
@@ -66,8 +64,7 @@
                             "type": "Placeable",
                             "expression": {
                                 "type": "NumberLiteral",
-                                "value": 1,
-                                "precision": 0
+                                "value": "1"
                             }
                         }
                     }

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -31,8 +31,7 @@
                                     "type": "Variant",
                                     "key": {
                                         "type": "NumberLiteral",
-                                        "value": 0,
-                                        "precision": 0
+                                        "value": "0"
                                     },
                                     "value": {
                                         "type": "Pattern",

--- a/test/fixtures/sparse_entries.json
+++ b/test/fixtures/sparse_entries.json
@@ -114,8 +114,7 @@
                             "type": "SelectExpression",
                             "selector": {
                                 "type": "NumberLiteral",
-                                "value": 1,
-                                "precision": 0
+                                "value": "1"
                             },
                             "variants": [
                                 {

--- a/test/fixtures/term_parameters.json
+++ b/test/fixtures/term_parameters.json
@@ -133,8 +133,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     }
                                 ]
@@ -182,8 +181,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 1,
-                                            "precision": 0
+                                            "value": "1"
                                         }
                                     },
                                     {
@@ -194,8 +192,7 @@
                                         },
                                         "value": {
                                             "type": "NumberLiteral",
-                                            "value": 2,
-                                            "precision": 0
+                                            "value": "2"
                                         }
                                     }
                                 ]

--- a/test/fixtures/variant_keys.json
+++ b/test/fixtures/variant_keys.json
@@ -118,8 +118,7 @@
                                     "type": "Variant",
                                     "key": {
                                         "type": "NumberLiteral",
-                                        "value": 1,
-                                        "precision": 0
+                                        "value": "1"
                                     },
                                     "value": {
                                         "type": "Pattern",
@@ -165,8 +164,7 @@
                                     "type": "Variant",
                                     "key": {
                                         "type": "NumberLiteral",
-                                        "value": 3.14,
-                                        "precision": 2
+                                        "value": "3.14"
                                     },
                                     "value": {
                                         "type": "Pattern",


### PR DESCRIPTION
Fix #239. Revert changes from #232 which made `value` be a float, and added `precision`. Also rename `value` to `raw` for consistency with `StringLiteral`. I'll file another issue to discuss removing unescaping from the AST and moving it into the resolver.