### PR TITLE
Fix Canadian English number formatting

### DIFF
--- a/guide/variables.md
+++ b/guide/variables.md
@@ -53,7 +53,7 @@ Time elapsed: 12,345.678s.
 In Canadian English, however, the result would be:
 
 ```
-Time elapsed: 12 345,678s.
+Time elapsed: 12 345.678s.
 ```
 
 ## Explicit Formatting


### PR DESCRIPTION
Not sure where the comma for a decimal marker came from, maybe Canadian French?
REF: https://www.btb.termiumplus.gc.ca/tcdnstyl-chap?lang=eng&lettr=chapsect5&info0=5.09