### PR TITLE
Use a placeholder email

### DIFF
--- a/guide/attributes.md
+++ b/guide/attributes.md
@@ -2,7 +2,7 @@
 
 ```
 login-input = Predefined value
-    .placeholder = example@email.com
+    .placeholder = email@example.com
     .aria-label = Login input value
     .title = Type your login email
 


### PR DESCRIPTION
In case that's someone's actual domain and/or email address

The example.com domain is expressly for this purpose:
http://example.com/