### PR TITLE
Duplicate switch case

### DIFF
--- a/lib/serializer.mjs
+++ b/lib/serializer.mjs
@@ -69,9 +69,6 @@ function serialize_operator({name, args}, state) {
         case "maybe": {
             return `${serialized_args[0]}?`;
         }
-        case "maybe": {
-            return `${serialized_args[0]}?`;
-        }
         case "never": {
             return null;
         }


### PR DESCRIPTION
If two cases in a switch statement have the same label, the second case will never be executed.

In JavaScript, cases in a switch statement can have arbitrary expressions as their labels. The interpreter does not check that these expressions are all different. At runtime, if two cases in a switch statement have the same label, the second case will never be executed. This most likely indicates a copy-paste error where the first case was copied and then not properly adjusted.