### PR TITLE
Add ordinal plural example to guide

### DIFF
--- a/guide/selectors.md
+++ b/guide/selectors.md
@@ -39,4 +39,17 @@ your-score =
     }
 ```
 
+Using formatting options also allows for selectors using ordinal rather than
+cardinal plurals:
+
+```
+your-rank = { NUMBER($pos, type: "ordinal") ->
+   [1] You finished first!
+   [one] You finished {$pos}st
+   [two] You finished {$pos}nd
+   [few] You finished {$pos}rd
+  *[other] You finished {$pos}th
+}
+```
+
 [CLDR plural category]: http://www.unicode.org/cldr/charts/30/supplemental/language_plural_rules.html


### PR DESCRIPTION
As it's by no means obvious that `NUMBER()` may also be used to implement selectors on ordinal rather than cardinal plural categories, this PR adds a note about this to the syntax guide.

What's happening here is that the same options that are passed to `Intl.NumberFormat` are also passed to `Intl.PluralRules`, and NumberFormat ignores the `type` option. Admittedly there is a bit of a wtf stage that you go through if you start to think about this.

I'm not sure how JS-specific this functionality is.