### PR TITLE
Complete test fixtures for invalid selector expressions, fixes #279

### DIFF
--- a/test/fixtures/select_expressions.ftl
+++ b/test/fixtures/select_expressions.ftl
@@ -21,6 +21,20 @@ invalid-selector-term-variant =
        *[key] value
     }
 
+# ERROR Nested expressions are not valid selectors
+invalid-selector-select-expression =
+    { { 3 } ->
+        *[key] default
+    }
+
+# ERROR Select expressions are not valid selectors
+invalid-selector-nested-expression =
+    { { $sel ->
+        *[key] value
+        } ->
+        *[key] default
+    }
+
 empty-variant =
     { $sel ->
        *[key] {""}

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -146,6 +146,24 @@
             "content": "invalid-selector-term-variant =\n    { -term(case: \"nominative\") ->\n       *[key] value\n    }\n\n"
         },
         {
+            "type": "Comment",
+            "content": "ERROR Nested expressions are not valid selectors"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "invalid-selector-select-expression =\n    { { 3 } ->\n        *[key] default\n    }\n\n"
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR Select expressions are not valid selectors"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "invalid-selector-nested-expression =\n    { { $sel ->\n        *[key] value\n        } ->\n        *[key] default\n    }\n\n"
+        },
+        {
             "type": "Message",
             "id": {
                 "type": "Identifier",


### PR DESCRIPTION
There were no tests for the full set of forbidden selector expressions.

That made it possible to pass the existing test suite while adding
`FTL.Placeable` to the list of allowed grammar productions in
`abstract.js`.
The test coverage is split between `select_expressions.ftl`, and
`reference_expressions.ftl`.

@zbraniecki, can you do the review duties here?