### PR TITLE
Add test validator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bench": "node -r esm --harmony-async-iteration ./test/bench.js ./test/benchmarks/gecko_strings.ftl",
     "build:guide": "gitbook build guide build/guide",
     "build": "npm run --silent build:guide",
-    "ci": "npm run --silent lint && npm test && npm run --silent test:ebnf",
+    "ci": "npm run --silent lint && npm test && npm run --silent test:ebnf && npm run --silent test:validate",
     "clean": "rm -rf build",
     "deploy": "gh-pages -d build",
     "generate:ebnf": "node -r esm bin/ebnf.js ./syntax/grammar.js > ./spec/fluent.ebnf",
@@ -15,9 +15,10 @@
     "generate": "npm run --silent generate:ebnf && npm run --silent generate:fixtures",
     "lint": "eslint **/*.js",
     "test:ebnf": "node -r esm test/ebnf.js ./syntax/grammar.js ./spec/fluent.ebnf",
-    "test:fixtures": "node -r esm test/parser.js ./test/fixtures",
+    "test:fixtures": "node -r esm --stack-size=500000000 test/parser.js ./test/fixtures",
+    "test:validate": "node -r esm --stack-size=500000000 test/validator.js ./test/fixtures",
     "test:unit": "node -r esm test/literals.js",
-    "test": "npm run --silent test:fixtures && npm run --silent test:unit"
+    "test": "npm run --silent test:fixtures && npm run --silent test:unit && npm run --silent test:validate"
   },
   "homepage": "https://projectfluent.org",
   "repository": {

--- a/test/fixtures/escaped_characters.ftl
+++ b/test/fixtures/escaped_characters.ftl
@@ -12,6 +12,9 @@ backslash-in-string = {"\\"}
 mismatched-quote = {"\\""}
 # ERROR Unknown escape
 unknown-escape = {"\x"}
+# ERROR Multiline literal
+invalid-multiline-literal = {"
+ "}
 
 ## Unicode escapes
 string-unicode-4digits = {"\u0041"}

--- a/test/fixtures/escaped_characters.json
+++ b/test/fixtures/escaped_characters.json
@@ -168,7 +168,16 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "unknown-escape = {\"\\x\"}\n\n"
+            "content": "unknown-escape = {\"\\x\"}\n"
+        },
+        {
+            "type": "Comment",
+            "content": "ERROR Multiline literal"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "invalid-multiline-literal = {\"\n \"}\n\n"
         },
         {
             "type": "GroupComment",

--- a/test/fixtures/select_indent.ftl
+++ b/test/fixtures/select_indent.ftl
@@ -15,6 +15,7 @@ select-1tbs-indent = {
 select-allman-inline =
 { $selector ->
    *[key] Value
+    [other] Other
 }
 
 select-allman-newline =

--- a/test/fixtures/select_indent.json
+++ b/test/fixtures/select_indent.json
@@ -176,6 +176,23 @@
                                         ]
                                     },
                                     "default": true
+                                },
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "other"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "TextElement",
+                                                "value": "Other"
+                                            }
+                                        ]
+                                    },
+                                    "default": false
                                 }
                             ]
                         }

--- a/test/parser.js
+++ b/test/parser.js
@@ -3,11 +3,12 @@ import path from "path";
 import {Resource} from "../syntax/grammar.js";
 import {readdir, readfile, diff, PASS, FAIL} from "./util.js";
 
-const fixtures_dir = process.argv[2];
+const bail = process.argv[2] === "--bail";
+const fixtures_dir = process.argv[bail ? 3 : 2];
 
 if (!fixtures_dir) {
     console.error(
-        "Usage: node -r esm parser.js FIXTURE");
+        "Usage: node -r esm parser.js [--bail] FIXTURE");
     process.exit(1);
 }
 

--- a/test/util.js
+++ b/test/util.js
@@ -37,6 +37,14 @@ export function readfile(path) {
     });
 }
 
+export function writefile(path, contents) {
+    return new Promise(function(resolve, reject) {
+        fs.writeFile(path, contents, function(err) {
+            return err ? reject(err) : resolve(path);
+        });
+    });
+}
+
 export const {diffString: diff} = json_diff;
 export const PASS = color.green("PASS");
 export const FAIL = color.red("FAIL");

--- a/test/validator.js
+++ b/test/validator.js
@@ -1,0 +1,113 @@
+import assert from "assert";
+import path from "path";
+import child_process from "child_process";
+import {readdir, readfile, writefile, PASS, FAIL} from "./util.js";
+import * as FTL from "../syntax/ast.js";
+
+const ABSTRACT = `${__dirname}/../syntax/abstract.js`;
+const GRAMMAR = `${__dirname}/../syntax/grammar.js`;
+const FIXTURES = `${__dirname}/fixtures`;
+
+main();
+
+async function main() {
+    let changed = await modify_grammar();
+    changed |= await validate_selector();
+    if (changed) {
+        child_process.execSync("git diff syntax",  { stdio: "inherit" });
+    }
+    process.exit(Number(changed));
+}
+
+async function modify_grammar() {
+    let changed = false;
+    let grammar = await readfile(GRAMMAR);
+    let to_replace = /(not|maybe)\(/g;
+    let m, iteration = 0;
+    while (m = to_replace.exec(grammar)) {
+        let replacement, new_grammar = grammar.slice(0, m.index);
+        switch (m[1]) {
+            case "not":
+                replacement = "maybe";
+                break;
+            case "maybe":
+                replacement = "not";
+                break;
+        }
+        new_grammar += replacement;
+        new_grammar += grammar.slice(m.index + m[1].length);
+        await writefile(GRAMMAR, new_grammar);
+        console.log(`Grammar validation iteration ${++iteration}`);
+        const keep_change = verify_fixtures();
+        if (keep_change) {
+            grammar = new_grammar;
+            changed = true;
+            console.log("new grammar");
+        }
+    }
+    await writefile(GRAMMAR, grammar);
+    return changed;
+}
+
+async function validate_selector() {
+    let changed = false;
+    let abstract = await readfile(ABSTRACT);
+    let expressions =
+        Object.values(FTL)
+        .filter(node => FTL.Expression.isPrototypeOf(node))
+        .map(node => node.name);
+    // This is a bit hacky, a Placeable can be a PatternElement and
+    // an expression, and is only typed to be the former.
+    expressions.push("Placeable");
+    let chunks = abstract.split(/(^.*?selector_is_valid.*$)/m);
+    assert.equal(chunks.length, 5);
+    let head = chunks.slice(0, 2).join("");
+    let valid_selector = chunks[2];
+    let tail = chunks.slice(3).join("");
+    assert.strictEqual([head, valid_selector, tail].join(""), abstract);
+    // Literals are abstract, and SelectExpression can only appear
+    // inside a Placeable.
+    let m, iteration = 0, checked_types = ["Literal", "SelectExpression"];
+    const instances = /selector instanceof FTL.([a-zA-Z]+)/g;
+    while (m = instances.exec(valid_selector)) {
+        checked_types.push(m[1]);
+        let new_valid = valid_selector.replace(
+            m[0],
+            `!(selector instanceof FTL.${m[1]})`
+        );
+        await writefile(ABSTRACT, [head, new_valid, tail].join(""));
+        console.log(`Abstract validation iteration ${++iteration}`);
+        const keep_change = verify_fixtures();
+        if (keep_change) {
+            valid_selector = new_valid;
+            changed = true;
+            console.log("new abstract");
+        }
+    }
+    for (const node of expressions) {
+        if (checked_types.includes(node)) {
+            continue;
+        }
+        let new_valid = `
+                    selector instanceof FTL.${node} ||${valid_selector}`;
+        await writefile(ABSTRACT, [head, new_valid, tail].join(""));
+        console.log(`Abstract validation iteration ${++iteration}`);
+        const keep_change = verify_fixtures();
+        if (keep_change) {
+            valid_selector = new_valid;
+            changed = true;
+            console.log("new abstract");
+        }
+    }
+    await writefile(ABSTRACT, [head, valid_selector, tail].join(""));
+    return changed;
+}
+
+function verify_fixtures() {
+    try {
+        child_process.execSync("node -r esm --stack-size=500000000 test/parser.js --bail " + FIXTURES);
+        return true;
+    } catch(e) {
+        return false;
+    }
+}

--- a/test/validator.js
+++ b/test/validator.js
@@ -19,6 +19,12 @@ async function main() {
     process.exit(Number(changed));
 }
 
+/**
+ * Modify grammar.js
+ *
+ * Both not() and maybe() match empty productions. Use them
+ * interchangably to see if we're still passing tests.
+ */
 async function modify_grammar() {
     let changed = false;
     let grammar = await readfile(GRAMMAR);
@@ -49,6 +55,13 @@ async function modify_grammar() {
     return changed;
 }
 
+/**
+ * Modify abstract.js
+ *
+ * Test if the constraints to selector expressions are all tested.
+ * Invert existing instanceof checks, and allow more AST nodes
+ * that can be returned by InlineExpression.
+ */
 async function validate_selector() {
     let changed = false;
     let abstract = await readfile(ABSTRACT);


### PR DESCRIPTION
This test ensures that there's only one specification that's
allowed by the tests, at least for some well-known cases.

The cases include `not` <-> `maybe`, both of which can be empty,
and some modifications to the allowed selectors in abstract.js.