### PR TITLE
Add more cases to validation.

### DIFF
--- a/lib/combinators.js
+++ b/lib/combinators.js
@@ -110,6 +110,12 @@ export function sequence(...parsers) {
         always([]));
 }
 
+// Test combinator to produce an empty list instead of
+// repeat or repeat1.
+export function repeat0(parser) {
+    return new Parser(stream => new Success([], stream));
+}
+
 export function repeat(parser) {
     return new Parser(stream =>
         parser

--- a/syntax/grammar.js
+++ b/syntax/grammar.js
@@ -2,11 +2,14 @@ import * as FTL from "./ast.js";
 import {list_into, into} from "./abstract.js";
 import {
     always, and, charset, defer, either, eof, maybe, not,
-    regex, repeat, repeat1, sequence, string
+    regex, repeat0, repeat, repeat1, sequence, string
 } from "../lib/combinators.js";
 import {
     element_at, flatten, join, keep_abstract, mutate, print, prune
 } from "../lib/mappers.js";
+
+// repeat0 is only imported for validation tests.
+repeat0;
 
 /* ----------------------------------------------------- */
 /* An FTL file defines a Resource consisting of Entries. */

--- a/test/fixtures/comments.ftl
+++ b/test/fixtures/comments.ftl
@@ -9,7 +9,12 @@ foo = Foo
 -term = Term
 
 # Another standalone
-#
+# 
 #      with indent
 ## Group Comment
 ### Resource Comment
+
+# Errors
+#error
+##error
+###error

--- a/test/fixtures/comments.json
+++ b/test/fixtures/comments.json
@@ -58,6 +58,25 @@
         {
             "type": "ResourceComment",
             "content": "Resource Comment"
+        },
+        {
+            "type": "Comment",
+            "content": "Errors"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "#error\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "##error\n"
+        },
+        {
+            "type": "Junk",
+            "annotations": [],
+            "content": "###error\n"
         }
     ]
 }

--- a/test/fixtures/messages.ftl
+++ b/test/fixtures/messages.ftl
@@ -18,6 +18,12 @@ key04 =
 key05 =                
     .attr1 = Attribute 1
 
+no-whitespace=Value
+    .attr1=Attribute 1
+
+extra-whitespace    =  Value
+    .attr1   =      Attribute 1
+
 key06 = {""}
 
 # JUNK Missing value

--- a/test/fixtures/messages.json
+++ b/test/fixtures/messages.json
@@ -209,6 +209,76 @@
             "type": "Message",
             "id": {
                 "type": "Identifier",
+                "name": "no-whitespace"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr1"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Attribute 1"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "extra-whitespace"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr1"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Attribute 1"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
                 "name": "key06"
             },
             "value": {

--- a/test/fixtures/select_expressions.ftl
+++ b/test/fixtures/select_expressions.ftl
@@ -22,13 +22,13 @@ invalid-selector-term-variant =
     }
 
 # ERROR Nested expressions are not valid selectors
-invalid-selector-select-expression =
+invalid-selector-nested-expression =
     { { 3 } ->
         *[key] default
     }
 
 # ERROR Select expressions are not valid selectors
-invalid-selector-nested-expression =
+invalid-selector-select-expression =
     { { $sel ->
         *[key] value
         } ->
@@ -37,6 +37,11 @@ invalid-selector-nested-expression =
 
 empty-variant =
     { $sel ->
+       *[key] {""}
+    }
+
+reduced-whitespace =
+    {FOO()->
        *[key] {""}
     }
 

--- a/test/fixtures/select_expressions.json
+++ b/test/fixtures/select_expressions.json
@@ -152,7 +152,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "invalid-selector-select-expression =\n    { { 3 } ->\n        *[key] default\n    }\n\n"
+            "content": "invalid-selector-nested-expression =\n    { { 3 } ->\n        *[key] default\n    }\n\n"
         },
         {
             "type": "Comment",
@@ -161,7 +161,7 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "invalid-selector-nested-expression =\n    { { $sel ->\n        *[key] value\n        } ->\n        *[key] default\n    }\n\n"
+            "content": "invalid-selector-select-expression =\n    { { $sel ->\n        *[key] value\n        } ->\n        *[key] default\n    }\n\n"
         },
         {
             "type": "Message",
@@ -181,6 +181,60 @@
                                 "id": {
                                     "type": "Identifier",
                                     "name": "sel"
+                                }
+                            },
+                            "variants": [
+                                {
+                                    "type": "Variant",
+                                    "key": {
+                                        "type": "Identifier",
+                                        "name": "key"
+                                    },
+                                    "value": {
+                                        "type": "Pattern",
+                                        "elements": [
+                                            {
+                                                "type": "Placeable",
+                                                "expression": {
+                                                    "value": "",
+                                                    "type": "StringLiteral"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "default": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "reduced-whitespace"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "SelectExpression",
+                            "selector": {
+                                "type": "FunctionReference",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "FOO"
+                                },
+                                "arguments": {
+                                    "type": "CallArguments",
+                                    "positional": [],
+                                    "named": []
                                 }
                             },
                             "variants": [

--- a/test/fixtures/terms.ftl
+++ b/test/fixtures/terms.ftl
@@ -21,3 +21,9 @@
 
 # JUNK Missing =
 -term07
+
+-term08=Value
+    .attr=Attribute
+
+-term09   =  Value
+    .attr  =   Attribute

--- a/test/fixtures/terms.json
+++ b/test/fixtures/terms.json
@@ -100,7 +100,77 @@
         {
             "type": "Junk",
             "annotations": [],
-            "content": "-term07\n"
+            "content": "-term07\n\n"
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "term08"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Attribute"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": null
+        },
+        {
+            "type": "Term",
+            "id": {
+                "type": "Identifier",
+                "name": "term09"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "TextElement",
+                        "value": "Value"
+                    }
+                ]
+            },
+            "attributes": [
+                {
+                    "type": "Attribute",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "attr"
+                    },
+                    "value": {
+                        "type": "Pattern",
+                        "elements": [
+                            {
+                                "type": "TextElement",
+                                "value": "Attribute"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "comment": null
         }
     ]
 }

--- a/test/fixtures/zero_length.json
+++ b/test/fixtures/zero_length.json
@@ -1,0 +1,4 @@
+{
+    "type": "Resource",
+    "body": []
+}


### PR DESCRIPTION
This is adding more options to more combinators.
There's one thing I didn't find out how to validate, and that
repeat1 should cover 1 and 2, and I don't think that's possible
to validate. I tried tracing the production calls in a different
patch, but that didn't return anything useful as it doesn't count
if the 2-match ends up in a parser error somewhere else in the
message.

@SirNickolas, can you give this a look? Also, Zibi?