### PR TITLE
Add link to Lua implementation project

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ We also know about the following community-driven implementations:
   - [`Fluent.Net`](https://github.com/blushingpenguin/Fluent.Net) by [@blushingpenguin](https://github.com/blushingpenguin). See [#93](https://github.com/projectfluent/fluent/issues/93) for more info.
   - A Java/Kotlin implementation has been requested in [#158](https://github.com/projectfluent/fluent/issues/158).
   - [`elm-fluent`](https://github.com/elm-fluent/elm-fluent) by [@spookylukey](https://github.com/spookylukey/)
+  - A Lua implementation effort is underway at [`fluent-lua`](https://github.com/alerque/fluent-lua) by [@alerque](https://github.com/alerque).
 
 ## Learn More and Discuss
 


### PR DESCRIPTION
As @Pike [suggested on Discourse](https://discourse.mozilla.org/t/work-started-on-a-lua-implementation/44963/2?u=alerque), here is a cross-link the the Lua implementation I'm working on for community mention section. 

I noticed this will conflict with #250 (which I think should also be merged, I've been comparing implementations for days and never saw it!). I'd be happy to rebase to fix the conflict after that is merged.