### PR TITLE
Add link to D implementation project

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ We also know about the following community-driven implementations:
   - A Java/Kotlin implementation has been requested in [#158](https://github.com/projectfluent/fluent/issues/158).
   - [`elm-fluent`](https://github.com/elm-fluent/elm-fluent) by [@spookylukey](https://github.com/spookylukey/)
   - A Lua implementation effort is underway at [`fluent-lua`](https://github.com/alerque/fluent-lua) by [@alerque](https://github.com/alerque).
+  - A D implementation effort is underway at [`fluentd`](https://github.com/SirNickolas/fluentd) by [@SirNickolas](https://github.com/SirNickolas).
 
 ## Learn More and Discuss
 


### PR DESCRIPTION
Thanks to the author cross-linking an issue related to my Lua implementation, I just found [this work in progress D implementation](https://github.com/SirNickolas/fluentd) of Fluent. I think it would be useful to link to all the finished or substantially in-progress implementations. Given that I've specifically been looking for implementations to review and didn't find this the visibility isn't good for community implementations that aren't linked here. I realize this is a work in progress and not ready for use, but getting visibility to parties interested in the language is a good way to get contributors and feedback that will drive the implementations forward.

Marking this PR as a draft pending @SirNickolas confirming he actually _wants_ the visibility ;-)

Also related, the working Perl implementation still isn't linked, see #250.