### PR TITLE
Fix #323, add more line continuations to cr and crlf tests

### DIFF
--- a/test/fixtures/cr.ftl
+++ b/test/fixtures/cr.ftl
@@ -1,1 +1,1 @@
-### This entire file uses CR as EOL.err01 = Value 01err02 = Value 02err03 =    Value 03    Continued    .title = Titleerr04 = { "strerr05 = { $sel -> }
+### This entire file uses CR as EOL.err01 = Value 01err02 = Value 02err03 =    Value 03    Continued    and continued        and continued    .title = Titleerr04 = { "strerr05 = { $sel -> }

--- a/test/fixtures/cr.json
+++ b/test/fixtures/cr.json
@@ -3,7 +3,7 @@
     "body": [
         {
             "type": "ResourceComment",
-            "content": "This entire file uses CR as EOL.\r\rerr01 = Value 01\rerr02 = Value 02\r\rerr03 =\r\r    Value 03\r    Continued\r\r    .title = Title\r\rerr04 = { \"str\r\rerr05 = { $sel -> }\r"
+            "content": "This entire file uses CR as EOL.\r\rerr01 = Value 01\rerr02 = Value 02\r\rerr03 =\r\r    Value 03\r    Continued\r\r    and continued\r    \r    and continued\r\r    .title = Title\r\rerr04 = { \"str\r\rerr05 = { $sel -> }\r"
         }
     ]
 }

--- a/test/fixtures/crlf.ftl
+++ b/test/fixtures/crlf.ftl
@@ -5,6 +5,10 @@ key02 =
     Value 02
     Continued
 
+    and continued
+    
+    and continued
+
     .title = Title
 
 # ERROR Unclosed StringLiteral

--- a/test/fixtures/crlf.json
+++ b/test/fixtures/crlf.json
@@ -30,7 +30,7 @@
                 "elements": [
                     {
                         "type": "TextElement",
-                        "value": "Value 02\nContinued"
+                        "value": "Value 02\nContinued\n\nand continued\n\nand continued"
                     }
                 ]
             },


### PR DESCRIPTION
I'm not happy with the `cr` test. It lumps all the combinations into the comments production, instead of actually testing `cr` handling in the various scenarios.

@zbraniecki, @stasm, any comments?

I'm entertaining the idea of splitting the `cr` test into a fixture for each block, but that's also very ad-hoc. Maybe with a trailing comment to explain what the test does and why.