### PR TITLE
Fix bogus comment syntax is benchmark content

### DIFF
--- a/test/benchmarks/gecko_strings.ftl
+++ b/test/benchmarks/gecko_strings.ftl
@@ -543,8 +543,8 @@ languages-customize-select-language =
 languages-customize-add =
     .label = Add
     .accesskey = A
-// Variables:
-//   $num - default value of the `dom.ipc.processCount` pref.
+# Variables:
+#   $num - default value of the `dom.ipc.processCount` pref.
 default-content-process-count
     .label = { $num } (default)
 # This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
I'm ran across this while working on adding Fluent support to Linguist (see https://github.com/github/linguist/pull/5341). This doesn't seem to be valid Fluent syntax at all, at best it would end up being a Junk block.

I also couldn't find this in Gecko sources anywhere. Everywhere else this [same content appears](https://grep.app/search?q=%24num%20-%20default%20value%20of%20the%20%60dom.ipc.processCount%60%20pref) it has clearly been fixed to be a valid Fluent comment. I don't see why that shouldn't be done here too.