### PR TITLE
Correct link to CLDR plural selectors

### DIFF
--- a/guide/selectors.md
+++ b/guide/selectors.md
@@ -52,4 +52,4 @@ your-rank = { NUMBER($pos, type: "ordinal") ->
 }
 ```
 
-[CLDR plural category]: http://www.unicode.org/cldr/charts/30/supplemental/language_plural_rules.html
+[CLDR plural category]: https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html


### PR DESCRIPTION
Current link redirects to a (quite heavy) zip download, this link redirects to the last version of the correct page.