### PR TITLE
Deploy mdbook in guide folder, preserve branch history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,4 +40,4 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
       - name: Deploy to GitHub pages
         run: |
-          npx gh-pages --message "Deploy docs" --no-history --dist build
+          npx gh-pages --message "Deploy docs" --dist build

--- a/book.toml
+++ b/book.toml
@@ -3,7 +3,7 @@ multilingual = false
 src = "guide"
 
 [build]
-build-dir = "build"
+build-dir = "build/guide"
 create-missing = false
 
 [output.html]


### PR DESCRIPTION
This builds the book in a `guide` subfolder, and preserves the history of the `gh-pages` branch (in case of issues).

Fixes #366 