### PR TITLE
Correct typos in test fixtures

### DIFF
--- a/test/fixtures/call_expressions.ftl
+++ b/test/fixtures/call_expressions.ftl
@@ -80,11 +80,11 @@ unindented-closing-paren = {FUN(
 one-argument = {FUN(1,)}
 many-arguments = {FUN(1, 2, 3,)}
 inline-sparse-args = {FUN(  1,  2,  3,  )}
-mulitline-args = {FUN(
+multiline-args = {FUN(
         1,
         2,
     )}
-mulitline-sparse-args = {FUN(
+multiline-sparse-args = {FUN(
 
         1
         ,

--- a/test/fixtures/call_expressions.json
+++ b/test/fixtures/call_expressions.json
@@ -1022,7 +1022,7 @@
             "type": "Message",
             "id": {
                 "type": "Identifier",
-                "name": "mulitline-args"
+                "name": "multiline-args"
             },
             "value": {
                 "type": "Pattern",
@@ -1060,7 +1060,7 @@
             "type": "Message",
             "id": {
                 "type": "Identifier",
-                "name": "mulitline-sparse-args"
+                "name": "multiline-sparse-args"
             },
             "value": {
                 "type": "Pattern",


### PR DESCRIPTION
I discovered these typos in a downstream repo (fluent-rs)