### PR TITLE
Allow VariableReference as NamedArgument value

### DIFF
--- a/guide/functions.md
+++ b/guide/functions.md
@@ -30,6 +30,10 @@ are only available to developers when they pre-format variables passed as
 arguments to translations (see [Partially-formatted
 variables](#partially-formatted-variables) below).
 
+Any inline expression may be used as a positional argument,
+but named argument values are limited to literal values in Fluent 1.0.
+In Fluent 1.1, a variable reference may also be used as a named argument value.
+
 ## Built-in Functions
 
 Built-in functions are very generic and should be applicable to any translation

--- a/guide/terms.md
+++ b/guide/terms.md
@@ -20,7 +20,8 @@ or they can interpolate other expressions, including variables. However,
 while messages receive data for variables directly from the app, terms
 receive such data from messages in which they are used. Such references take
 the form of `-term(…)` where the variables available inside of the term are
-defined between the parentheses, e.g. `-term(param: "value")`.
+defined between the parentheses, e.g. `-term(param: "value")` or
+`-term(param: $arg)` (starting from Fluent 1.1).
 
 ```
 # A contrived example to demonstrate how variables

--- a/spec/fluent.ebnf
+++ b/spec/fluent.ebnf
@@ -72,7 +72,7 @@ CallArguments       ::= blank? "(" blank? argument_list blank? ")"
 argument_list       ::= (Argument blank? "," blank?)* Argument?
 Argument            ::= NamedArgument
                       | InlineExpression
-NamedArgument       ::= Identifier blank? ":" blank? (StringLiteral | NumberLiteral)
+NamedArgument       ::= Identifier blank? ":" blank? (StringLiteral | NumberLiteral | VariableReference)
 
 /* Block Expressions */
 SelectExpression    ::= InlineExpression blank? "->" blank_inline? variant_list

--- a/syntax/grammar.js
+++ b/syntax/grammar.js
@@ -302,7 +302,8 @@ let NamedArgument = defer(() =>
         maybe(blank),
         either(
             StringLiteral,
-            NumberLiteral).abstract)
+            NumberLiteral,
+            VariableReference).abstract)
     .map(keep_abstract)
     .chain(list_into(FTL.NamedArgument)));
 

--- a/test/fixtures/call_expressions.ftl
+++ b/test/fixtures/call_expressions.ftl
@@ -19,6 +19,7 @@ positional-args = {FUN(1, "a", msg)}
 named-args = {FUN(x: 1, y: "Y")}
 dense-named-args = {FUN(x:1, y:"Y")}
 mixed-args = {FUN(1, "a", msg, x: 1, y: "Y")}
+variable-args = {FUN($foo, arg: $bar)}
 
 # ERROR Positional arg must not follow keyword args
 shuffled-args = {FUN(1, x: 1, "a", y: "Y", msg)}

--- a/test/fixtures/call_expressions.json
+++ b/test/fixtures/call_expressions.json
@@ -352,6 +352,58 @@
             "comment": null
         },
         {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "variable-args"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "FunctionReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "FUN"
+                            },
+                            "arguments": {
+                                "type": "CallArguments",
+                                "positional": [
+                                    {
+                                        "type": "VariableReference",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "foo"
+                                        }
+                                    }
+                                ],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "arg"
+                                        },
+                                        "value": {
+                                            "type": "VariableReference",
+                                            "id": {
+                                                "type": "Identifier",
+                                                "name": "bar"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
+        },
+        {
             "type": "Comment",
             "content": "ERROR Positional arg must not follow keyword args"
         },

--- a/test/fixtures/term_parameters.ftl
+++ b/test/fixtures/term_parameters.ftl
@@ -6,3 +6,4 @@ key01 = { -term }
 key02 = { -term () }
 key03 = { -term(arg: 1) }
 key04 = { -term("positional", narg1: 1, narg2: 2) }
+key05 = { -term(arg: $foo) }

--- a/test/fixtures/term_parameters.json
+++ b/test/fixtures/term_parameters.json
@@ -202,6 +202,51 @@
             },
             "attributes": [],
             "comment": null
+        },
+        {
+            "type": "Message",
+            "id": {
+                "type": "Identifier",
+                "name": "key05"
+            },
+            "value": {
+                "type": "Pattern",
+                "elements": [
+                    {
+                        "type": "Placeable",
+                        "expression": {
+                            "type": "TermReference",
+                            "id": {
+                                "type": "Identifier",
+                                "name": "term"
+                            },
+                            "attribute": null,
+                            "arguments": {
+                                "type": "CallArguments",
+                                "positional": [],
+                                "named": [
+                                    {
+                                        "type": "NamedArgument",
+                                        "name": {
+                                            "type": "Identifier",
+                                            "name": "arg"
+                                        },
+                                        "value": {
+                                            "type": "VariableReference",
+                                            "id": {
+                                                "type": "Identifier",
+                                                "name": "foo"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            },
+            "attributes": [],
+            "comment": null
         }
     ]
 }


### PR DESCRIPTION
- Closes #230
- Closes #325
- Closes #337
- See also #349
- Closes #369

This proposed syntax change would require the release of a new Fluent version, probably 1.1. It's forwards-incompatible, i.e. while all Fluent 1.0 content is valid Fluent 1.1, not all Fluent 1.1 content would be considered valid by a Fluent 1.0 processor.

Effectively, this would allow for usage like:
```fluent
-term = the { $foo } term
msg-1 = This message includes { -term(foo: $term) }.
msg-2 = This message formats { NUMBER($n, minimumFractionDigits: $fd) }.
```

Not all inline expression values are supported as named arguments, so e.g. `{ -term(foo: -bar) }` would continue to be a syntax error. My sense is that the strong, active desire is only for variable references, and that other uses are much more limited.

I'll be sumitting PRs for fluent.js and python-fluent to showcase the impact on implementations. From #325 I gather that fluent-rs might already support this, or that it's likely to be relatively straightforward to add there.

We'll need to consider carefully how to handle this in Pontoon, as we may need a per-project configuration of the supported Fluent version, or we need a solution for #208.

In Firefox, we'll need to review the capabilities of the fluent-rs version we're using.